### PR TITLE
Fix pnpm cache usage in pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "pnpm"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- remove pnpm cache configuration from the Pages workflow so pnpm is no longer required before setup-node runs

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca86e2f0e883208068428b86c80207