### PR TITLE
feat: add responsive links app window

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,15 @@
   "dependencies": {
     "@astrojs/svelte": "^6.0.0",
     "@astrojs/tailwind": "^5.1.0",
+    "@iconify/svelte": "^5.0.2",
     "astro": "^4.16.19",
+    "motion": "^12.23.13",
+    "qrcode-generator": "^2.0.4",
     "svelte": "^5.1.16",
     "zod": "^3.25.8"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.4",
     "@axe-core/playwright": "^4.10.2",
     "@biomejs/biome": "^2.2.4",
     "@playwright/test": "^1.55.0",
@@ -45,7 +49,6 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.9.2",
-    "vitest": "^3.2.4",
-    "@astrojs/check": "^0.9.4"
+    "vitest": "^3.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,18 @@ importers:
       '@astrojs/tailwind':
         specifier: ^5.1.0
         version: 5.1.5(astro@4.16.19(@types/node@22.18.5)(rollup@4.50.2)(typescript@5.9.2))(tailwindcss@3.4.17)
+      '@iconify/svelte':
+        specifier: ^5.0.2
+        version: 5.0.2(svelte@5.38.10)
       astro:
         specifier: ^4.16.19
         version: 4.16.19(@types/node@22.18.5)(rollup@4.50.2)(typescript@5.9.2)
+      motion:
+        specifier: ^12.23.13
+        version: 12.23.13
+      qrcode-generator:
+        specifier: ^2.0.4
+        version: 2.0.4
       svelte:
         specifier: ^5.1.16
         version: 5.38.10
@@ -639,6 +648,14 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@iconify/svelte@5.0.2':
+    resolution: {integrity: sha512-1iWUT+1veS/QOAzKDG0NPgBtJYGoJqEPwF97voTm8jw6PQ6yU0hL73lEwFoTGMrZmatLvh9cjRBmeSHHaltmrg==}
+    peerDependencies:
+      svelte: '>4.0.0'
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -1570,6 +1587,20 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  framer-motion@12.23.13:
+    resolution: {integrity: sha512-OMF57Xh0fuTXfJQPtCieYGeU9Fam4SxqPLVz78YI7ATRFrfz8SARtqr1+qv56cX45kPFcIEfkUorVfxlOsjcUg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2073,6 +2104,26 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  motion-dom@12.23.12:
+    resolution: {integrity: sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==}
+
+  motion-utils@12.23.6:
+    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
+
+  motion@12.23.13:
+    resolution: {integrity: sha512-kqmtRlqMuSJAMeHmYD+BPJNPGCUBXKqDuYpfuEh+mud9Y2gpSUrIXQRhCNkKzGlwOpbgbJocSJR5aKvhzyqFQg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -2306,6 +2357,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode-generator@2.0.4:
+    resolution: {integrity: sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==}
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -3540,6 +3594,13 @@ snapshots:
   '@esbuild/win32-x64@0.25.9':
     optional: true
 
+  '@iconify/svelte@5.0.2(svelte@5.38.10)':
+    dependencies:
+      '@iconify/types': 2.0.0
+      svelte: 5.38.10
+
+  '@iconify/types@2.0.0': {}
+
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.0.4
@@ -4549,6 +4610,12 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  framer-motion@12.23.13:
+    dependencies:
+      motion-dom: 12.23.12
+      motion-utils: 12.23.6
+      tslib: 2.8.1
+
   fsevents@2.3.2:
     optional: true
 
@@ -5271,6 +5338,17 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  motion-dom@12.23.12:
+    dependencies:
+      motion-utils: 12.23.6
+
+  motion-utils@12.23.6: {}
+
+  motion@12.23.13:
+    dependencies:
+      framer-motion: 12.23.13
+      tslib: 2.8.1
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -5480,6 +5558,8 @@ snapshots:
       punycode: 2.3.1
 
   punycode@2.3.1: {}
+
+  qrcode-generator@2.0.4: {}
 
   querystringify@2.2.0: {}
 

--- a/src/components/LinksApp.svelte
+++ b/src/components/LinksApp.svelte
@@ -1,0 +1,623 @@
+<script lang="ts">
+  import { animate, stagger } from 'motion';
+  import { onDestroy, onMount } from 'svelte';
+  import { createQrSvg } from '../lib/qr';
+  import type {
+    ResolvedProfile,
+    ResolvedProfileLink,
+    ResolvedProfileSection,
+    ResolvedProfileSectionItem
+  } from '../stores/profileStore';
+
+  type IconComponent = typeof import('@iconify/svelte/dist/Icon.svelte').default;
+
+  const FALLBACK_ICON = 'lucide:link-2';
+  const CTA_CLASSES =
+    'border-accent/70 bg-accent text-surface shadow-glow shadow-accent/40 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-accent/40';
+  const LINK_CLASSES =
+    'border-accent/20 bg-surface-glare/70 hover:border-accent/60 hover:-translate-y-0.5 hover:shadow-glow';
+
+  export let profile: ResolvedProfile;
+  export let siteUrl: string;
+
+  let IconCtor: IconComponent | null = null;
+  let linksList: HTMLUListElement | null = null;
+  let resolvedSiteUrl = siteUrl;
+  let qrMarkup = '';
+  let copyAnnouncement = '';
+  let copiedKey: string | null = null;
+  let clearTimer: ReturnType<typeof setTimeout> | null = null;
+
+  interface SectionBucket extends ResolvedProfileSection {
+    key: string;
+  }
+
+  let updatesSection: SectionBucket | null = null;
+  let contactSection: SectionBucket | null = null;
+  let tipJarSection: SectionBucket | null = null;
+  let socialsSection: SectionBucket | null = null;
+  let nowPlayingSection: SectionBucket | null = null;
+  let extraSections: SectionBucket[] = [];
+
+  const hasWindow = typeof window !== 'undefined';
+
+  const formattedHandle = profile.handle
+    ? profile.handle.startsWith('@')
+      ? profile.handle
+      : `@${profile.handle}`
+    : '';
+
+  const loadIconComponent = async () => {
+    if (IconCtor) {
+      return IconCtor;
+    }
+
+    const module = await import('@iconify/svelte/dist/Icon.svelte');
+    IconCtor = module.default;
+    return IconCtor;
+  };
+
+  const animateLinks = () => {
+    if (!hasWindow || !linksList) {
+      return;
+    }
+
+    const items = Array.from(linksList.querySelectorAll('[data-link]')) as HTMLElement[];
+    if (!items.length) {
+      return;
+    }
+
+    animate(
+      items,
+      { opacity: [0, 1], transform: ['translateY(8px)', 'translateY(0)'] },
+      { delay: stagger(0.045), duration: 0.35, easing: 'ease-out' }
+    );
+  };
+
+  const normalizeKey = (value: string) =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .trim();
+
+  const computeSections = () => {
+    const pool: SectionBucket[] = (profile.sections ?? []).map((section) => ({
+      ...section,
+      key: normalizeKey(section.title)
+    }));
+
+    const takeSection = (keys: string[]): SectionBucket | null => {
+      const index = pool.findIndex((candidate) => keys.includes(candidate.key));
+      if (index === -1) {
+        return null;
+      }
+      const [section] = pool.splice(index, 1);
+      return section ?? null;
+    };
+
+    updatesSection = takeSection(['updates', 'update log']);
+    contactSection = takeSection(['contact', 'contact info']);
+    tipJarSection = takeSection(['tip jar', 'support', 'support us']);
+    socialsSection = takeSection(['socials', 'social', 'community']);
+    nowPlayingSection = takeSection(['now playing', 'now-playing', 'playing now']);
+    extraSections = pool;
+  };
+
+  const generateQrMarkup = () => {
+    const value = resolvedSiteUrl || siteUrl;
+    qrMarkup = createQrSvg(value, {
+      size: 196,
+      margin: 12,
+      color: 'currentColor',
+      background: 'transparent',
+      ariaLabel: 'QR code linking to this page'
+    });
+  };
+
+  $: profile, computeSections();
+
+  $: resolvedSiteUrl, siteUrl, generateQrMarkup();
+
+  onMount(() => {
+    void loadIconComponent();
+
+    if (hasWindow) {
+      resolvedSiteUrl = window.location.href;
+      generateQrMarkup();
+      queueMicrotask(animateLinks);
+    }
+  });
+
+  onDestroy(() => {
+    if (clearTimer) {
+      clearTimeout(clearTimer);
+      clearTimer = null;
+    }
+  });
+
+  const resetCopyState = () => {
+    if (clearTimer) {
+      clearTimeout(clearTimer);
+    }
+
+    clearTimer = setTimeout(() => {
+      copiedKey = null;
+      copyAnnouncement = '';
+      clearTimer = null;
+    }, 2200);
+  };
+
+  const execCopyFallback = (value: string) => {
+    if (!hasWindow || typeof document === 'undefined') {
+      return false;
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = value;
+    textarea.setAttribute('readonly', 'true');
+    textarea.style.position = 'absolute';
+    textarea.style.opacity = '0';
+    textarea.style.pointerEvents = 'none';
+    document.body.appendChild(textarea);
+
+    const selection = window.getSelection();
+    const previousRange = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+
+    textarea.select();
+    let success = false;
+
+    try {
+      success = document.execCommand('copy');
+    } catch (error) {
+      success = false;
+    }
+
+    document.body.removeChild(textarea);
+
+    if (previousRange && selection) {
+      selection.removeAllRanges();
+      selection.addRange(previousRange);
+    }
+
+    return success;
+  };
+
+  const copyText = async (value: string) => {
+    if (!value || value.trim() === '') {
+      return false;
+    }
+
+    if (hasWindow && navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(value);
+        return true;
+      } catch (error) {
+        // noop, fall back to execCommand
+      }
+    }
+
+    return execCopyFallback(value);
+  };
+
+  const handleCopy = async (key: string, value: string | null, label: string) => {
+    if (!value || value.trim() === '') {
+      copyAnnouncement = `${label} is empty.`;
+      copiedKey = null;
+      resetCopyState();
+      return;
+    }
+
+    const success = await copyText(value);
+    copiedKey = success ? key : null;
+    copyAnnouncement = success
+      ? `${label} copied to clipboard.`
+      : `Unable to copy ${label}.`;
+    resetCopyState();
+  };
+
+  const formatLinkHost = (url: string) => {
+    if (url.startsWith('mailto:')) {
+      return url.slice('mailto:'.length);
+    }
+
+    try {
+      const parsed = new URL(url);
+      return parsed.host.replace(/^www\./, '');
+    } catch (error) {
+      return url;
+    }
+  };
+
+  const resolveLinkIcon = (link: ResolvedProfileLink) => link.icon || FALLBACK_ICON;
+
+  const sectionItemKey = (section: SectionBucket, item: ResolvedProfileSectionItem, index: number) =>
+    `${section.key}-${index}`;
+
+  const sectionItemPrimary = (item: ResolvedProfileSectionItem) =>
+    item.value ?? item.text ?? '';
+
+  const sectionItemSecondary = (item: ResolvedProfileSectionItem) => item.note ?? '';
+
+  const sectionItemLabel = (item: ResolvedProfileSectionItem) =>
+    item.label ?? (item.text ? '' : sectionItemPrimary(item));
+</script>
+
+<div class="flex h-full min-h-0 flex-col">
+  <div class="flex-1 overflow-y-auto px-4 pb-5 pt-4 sm:px-6 sm:pt-6">
+    <div class="mx-auto flex w-full max-w-3xl flex-col gap-6">
+      <header class="flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-6">
+        {#if profile.avatar}
+          <div class="flex-shrink-0">
+            <img
+              class="h-20 w-20 rounded-3xl border border-accent/40 object-cover shadow-glow shadow-accent/30 sm:h-24 sm:w-24"
+              src={profile.avatar}
+              alt={`Avatar for ${profile.displayName}`}
+              loading="lazy"
+              decoding="async"
+            />
+          </div>
+        {/if}
+        <div class="min-w-0 space-y-3">
+          <div class="flex flex-wrap items-center gap-3">
+            <h1 class="text-2xl font-semibold tracking-tight text-text sm:text-3xl">
+              {profile.displayName}
+            </h1>
+            {#if formattedHandle}
+              <button
+                type="button"
+                class="inline-flex items-center gap-2 rounded-full border border-accent/40 bg-surface-glare/60 px-3 py-1 text-xs font-medium uppercase tracking-wide text-accent transition hover:border-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+                on:click={() => handleCopy('handle', formattedHandle, 'Handle')}
+              >
+                <span>{formattedHandle}</span>
+                <span class="text-[0.65rem] font-semibold tracking-widest text-accent/80">
+                  {copiedKey === 'handle' ? 'Copied' : 'Copy'}
+                </span>
+              </button>
+            {/if}
+          </div>
+          <p class="text-sm leading-relaxed text-muted sm:text-base">{profile.bio}</p>
+        </div>
+      </header>
+
+      <section aria-labelledby="links-heading" class="space-y-3">
+        <div class="flex items-center justify-between">
+          <h2 id="links-heading" class="text-xs font-semibold uppercase tracking-[0.3em] text-muted">
+            Signals
+          </h2>
+          <span class="text-xs font-medium text-accent/80">{profile.links.length} active</span>
+        </div>
+        <ul class="flex flex-col gap-3" bind:this={linksList}>
+          {#each profile.links as link (link.url)}
+            <li>
+              <a
+                class={`group flex items-center justify-between gap-4 rounded-3xl border px-4 py-4 text-base transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface sm:px-6 ${
+                  link.cta ? CTA_CLASSES : LINK_CLASSES
+                }`}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-link
+              >
+                <div class="flex items-center gap-4">
+                  <div
+                    class={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl border ${
+                      link.cta
+                        ? 'border-surface/30 bg-surface/20 text-surface'
+                        : 'border-accent/30 bg-surface text-accent'
+                    }`}
+                  >
+                    {#if IconCtor}
+                      <svelte:component
+                        this={IconCtor}
+                        icon={resolveLinkIcon(link)}
+                        class={`h-5 w-5 ${link.cta ? 'text-surface' : 'text-accent'}`}
+                        aria-hidden="true"
+                      />
+                    {:else}
+                      <span aria-hidden="true" class="text-lg">🔗</span>
+                    {/if}
+                  </div>
+                  <div class="min-w-0">
+                    <div class="flex items-center gap-2 text-left">
+                      <span class="font-semibold tracking-tight">
+                        {link.label}
+                      </span>
+                      {#if link.badge}
+                        <span
+                          class={`inline-flex items-center rounded-full border px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-[0.3em] ${
+                            link.cta
+                              ? 'border-surface/40 text-surface/90'
+                              : 'border-accent/50 text-accent'
+                          }`}
+                        >
+                          {link.badge}
+                        </span>
+                      {/if}
+                    </div>
+                    <p class={`text-sm ${link.cta ? 'text-surface/80' : 'text-muted'}`}>
+                      {formatLinkHost(link.url)}
+                    </p>
+                  </div>
+                </div>
+                <span
+                  aria-hidden="true"
+                  class={`text-sm font-medium uppercase tracking-[0.3em] ${
+                    link.cta ? 'text-surface/90' : 'text-accent/80'
+                  }`}
+                >
+                  Tune
+                </span>
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </section>
+
+      <section class="grid gap-4 md:grid-cols-2">
+        {#if updatesSection}
+          <article class="rounded-3xl border border-accent/20 bg-surface-glare/60 p-4 shadow-inner shadow-accent/10">
+            <header class="flex items-center justify-between gap-3">
+              <h3 class="text-xs font-semibold uppercase tracking-[0.3em] text-muted">
+                {updatesSection.title}
+              </h3>
+              <span class="text-xs text-accent/70">Latest signal</span>
+            </header>
+            <ul class="mt-3 space-y-3 text-sm text-text">
+              {#each updatesSection.items as item, index (sectionItemKey(updatesSection, item, index))}
+                <li class="rounded-2xl border border-accent/10 bg-surface/60 px-3 py-2">
+                  {#if sectionItemLabel(item)}
+                    <p class="text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-accent/80">
+                      {sectionItemLabel(item)}
+                    </p>
+                  {/if}
+                  {#if sectionItemPrimary(item)}
+                    <p class="mt-1 text-[0.95rem] leading-snug text-text">
+                      {sectionItemPrimary(item)}
+                    </p>
+                  {/if}
+                  {#if sectionItemSecondary(item)}
+                    <p class="mt-1 text-xs text-muted">
+                      {sectionItemSecondary(item)}
+                    </p>
+                  {/if}
+                </li>
+              {/each}
+            </ul>
+          </article>
+        {/if}
+
+        <article class="flex flex-col gap-4 rounded-3xl border border-accent/20 bg-surface-glare/60 p-4">
+          <header class="flex items-center justify-between gap-3">
+            <h3 class="text-xs font-semibold uppercase tracking-[0.3em] text-muted">
+              {nowPlayingSection ? nowPlayingSection.title : 'Now Playing'}
+            </h3>
+            <span class="text-xs text-accent/70">Broadcast feed</span>
+          </header>
+          {#if nowPlayingSection && nowPlayingSection.items.length}
+            {#each nowPlayingSection.items as item, index (sectionItemKey(nowPlayingSection, item, index))}
+              <div class="rounded-2xl border border-accent/10 bg-surface px-3 py-3">
+                {#if sectionItemLabel(item)}
+                  <p class="text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-accent/80">
+                    {sectionItemLabel(item)}
+                  </p>
+                {/if}
+                <p class="mt-1 text-base font-medium text-text">
+                  {sectionItemPrimary(item) || 'Standby signal'}
+                </p>
+                <p class="mt-1 text-xs text-muted">
+                  {sectionItemSecondary(item) || 'Awaiting live transmission.'}
+                </p>
+              </div>
+            {/each}
+          {:else}
+            <div class="rounded-2xl border border-accent/10 bg-surface px-3 py-6 text-center">
+              <p class="text-base font-semibold text-text">No broadcast in progress.</p>
+              <p class="mt-1 text-xs text-muted">
+                Return soon for the next transmission.
+              </p>
+            </div>
+          {/if}
+        </article>
+      </section>
+
+      <section class="grid gap-4 md:grid-cols-2">
+        {#if contactSection}
+          <article class="rounded-3xl border border-accent/20 bg-surface-glare/60 p-4">
+            <header class="flex items-center justify-between gap-3">
+              <h3 class="text-xs font-semibold uppercase tracking-[0.3em] text-muted">
+                {contactSection.title}
+              </h3>
+              <span class="text-xs text-accent/70">Reach out</span>
+            </header>
+            <ul class="mt-3 space-y-3 text-sm text-text">
+              {#each contactSection.items as item, index (sectionItemKey(contactSection, item, index))}
+                <li class="rounded-2xl border border-accent/10 bg-surface/70 px-3 py-3">
+                  <div class="flex flex-wrap items-center gap-2">
+                    {#if sectionItemLabel(item)}
+                      <span class="text-xs font-semibold uppercase tracking-[0.35em] text-accent/80">
+                        {sectionItemLabel(item)}
+                      </span>
+                    {/if}
+                    {#if item.href}
+                      <a
+                        class="text-sm font-medium text-accent underline-offset-4 transition hover:underline"
+                        href={item.href}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        {sectionItemPrimary(item) || sectionItemLabel(item)}
+                      </a>
+                    {:else if sectionItemPrimary(item)}
+                      <span class="text-sm font-medium text-text">{sectionItemPrimary(item)}</span>
+                    {/if}
+                  </div>
+                  <div class="mt-2 flex flex-wrap items-center gap-2">
+                    {#if item.copyable && sectionItemPrimary(item)}
+                      <button
+                        type="button"
+                        class="rounded-full border border-accent/40 bg-surface px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-accent transition hover:border-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+                        on:click={() =>
+                          handleCopy(
+                            `${contactSection?.key ?? 'contact'}-${index}`,
+                            sectionItemPrimary(item),
+                            sectionItemLabel(item) || 'Contact detail'
+                          )
+                        }
+                      >
+                        {copiedKey === `${contactSection?.key ?? 'contact'}-${index}` ? 'Copied' : 'Copy'}
+                      </button>
+                    {/if}
+                    {#if sectionItemSecondary(item)}
+                      <span class="text-xs text-muted">{sectionItemSecondary(item)}</span>
+                    {/if}
+                  </div>
+                </li>
+              {/each}
+            </ul>
+          </article>
+        {/if}
+
+        {#if tipJarSection || socialsSection || extraSections.length}
+          <div class="space-y-4">
+            {#if tipJarSection}
+              <article class="rounded-3xl border border-accent/20 bg-surface-glare/60 p-4">
+                <header class="flex items-center justify-between gap-3">
+                  <h3 class="text-xs font-semibold uppercase tracking-[0.3em] text-muted">
+                    {tipJarSection.title}
+                  </h3>
+                  <span class="text-xs text-accent/70">Support</span>
+                </header>
+                <ul class="mt-3 space-y-3 text-sm text-text">
+                  {#each tipJarSection.items as item, index (sectionItemKey(tipJarSection, item, index))}
+                    <li class="rounded-2xl border border-accent/10 bg-surface/70 px-3 py-3">
+                      <div class="flex flex-wrap items-center gap-2">
+                        {#if sectionItemLabel(item)}
+                          <span class="text-xs font-semibold uppercase tracking-[0.35em] text-accent/80">
+                            {sectionItemLabel(item)}
+                          </span>
+                        {/if}
+                        {#if item.href}
+                          <a
+                            class="text-sm font-medium text-accent underline-offset-4 transition hover:underline"
+                            href={item.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            Visit
+                          </a>
+                        {:else if sectionItemPrimary(item)}
+                          <span class="text-sm font-medium text-text">{sectionItemPrimary(item)}</span>
+                        {/if}
+                      </div>
+                      {#if item.copyable && sectionItemPrimary(item)}
+                        <button
+                          type="button"
+                          class="mt-2 rounded-full border border-accent/40 bg-surface px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-accent transition hover:border-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+                          on:click={() =>
+                            handleCopy(
+                              `${tipJarSection?.key ?? 'tip-jar'}-${index}`,
+                              sectionItemPrimary(item),
+                              sectionItemLabel(item) || 'Tip jar detail'
+                            )
+                          }
+                        >
+                          {copiedKey === `${tipJarSection?.key ?? 'tip-jar'}-${index}` ? 'Copied' : 'Copy'}
+                        </button>
+                      {/if}
+                    </li>
+                  {/each}
+                </ul>
+              </article>
+            {/if}
+
+            {#if socialsSection}
+              <article class="rounded-3xl border border-accent/20 bg-surface-glare/60 p-4">
+                <header class="flex items-center justify-between gap-3">
+                  <h3 class="text-xs font-semibold uppercase tracking-[0.3em] text-muted">
+                    {socialsSection.title}
+                  </h3>
+                  <span class="text-xs text-accent/70">Find us</span>
+                </header>
+                <div class="mt-3 flex flex-wrap gap-2">
+                  {#each socialsSection.items as item, index (sectionItemKey(socialsSection, item, index))}
+                    {#if item.href}
+                      <a
+                        class="inline-flex items-center gap-2 rounded-full border border-accent/30 bg-surface px-3 py-2 text-sm font-medium text-text transition hover:border-accent/60 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+                        href={item.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <span class="inline-flex items-center justify-center">
+                          {#if IconCtor && item.icon}
+                            <svelte:component
+                              this={IconCtor}
+                              icon={item.icon}
+                              class="h-4 w-4 text-accent"
+                              aria-hidden="true"
+                            />
+                          {/if}
+                        </span>
+                        <span>{sectionItemLabel(item) || sectionItemPrimary(item)}</span>
+                      </a>
+                    {:else if sectionItemLabel(item)}
+                      <span class="inline-flex items-center gap-2 rounded-full border border-accent/30 bg-surface px-3 py-2 text-sm text-text">
+                        {sectionItemLabel(item)}
+                      </span>
+                    {/if}
+                  {/each}
+                </div>
+              </article>
+            {/if}
+
+            {#if extraSections.length}
+              {#each extraSections as section (section.key)}
+                <article class="rounded-3xl border border-accent/20 bg-surface-glare/60 p-4">
+                  <header class="flex items-center justify-between gap-3">
+                    <h3 class="text-xs font-semibold uppercase tracking-[0.3em] text-muted">
+                      {section.title}
+                    </h3>
+                    <span class="text-xs text-accent/70">Briefing</span>
+                  </header>
+                  <ul class="mt-3 space-y-2 text-sm text-text">
+                    {#each section.items as item, index (sectionItemKey(section, item, index))}
+                      <li class="rounded-2xl border border-accent/10 bg-surface/70 px-3 py-2">
+                        {#if sectionItemLabel(item)}
+                          <p class="text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-accent/80">
+                            {sectionItemLabel(item)}
+                          </p>
+                        {/if}
+                        <p class="mt-1 text-sm text-text">
+                          {sectionItemPrimary(item) || sectionItemLabel(item)}
+                        </p>
+                        {#if sectionItemSecondary(item)}
+                          <p class="mt-1 text-xs text-muted">{sectionItemSecondary(item)}</p>
+                        {/if}
+                      </li>
+                    {/each}
+                  </ul>
+                </article>
+              {/each}
+            {/if}
+          </div>
+        {/if}
+      </section>
+    </div>
+  </div>
+  <div class="border-t border-accent/20 bg-surface/90 px-4 py-4 backdrop-blur sm:px-6">
+    <div class="mx-auto flex w-full max-w-3xl flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex items-center gap-4">
+        <div class="rounded-2xl border border-accent/30 bg-surface px-4 py-4 text-accent">
+          {@html qrMarkup}
+        </div>
+        <div class="space-y-1">
+          <p class="text-sm font-semibold uppercase tracking-[0.3em] text-muted">Scan to tune</p>
+          <p class="text-sm text-text">Open this station on another device.</p>
+        </div>
+      </div>
+      <div class="text-xs text-muted">
+        <p>Share {resolvedSiteUrl || siteUrl}</p>
+      </div>
+    </div>
+    <p class="sr-only" aria-live="polite">{copyAnnouncement}</p>
+  </div>
+</div>

--- a/src/content/profile/default.json
+++ b/src/content/profile/default.json
@@ -9,7 +9,8 @@
       "label": "Main Site",
       "url": "https://example.com",
       "icon": "lucide:waveform",
-      "badge": "LIVE"
+      "badge": "LIVE",
+      "cta": true
     },
     {
       "label": "GitHub",
@@ -29,17 +30,72 @@
   ],
   "sections": [
     {
-      "title": "Broadcast Schedule",
+      "title": "Updates",
       "items": [
-        "Wednesday · 21:00 ET — Creative coding session",
-        "Friday · 22:30 ET — Signal test + Q&A"
+        {
+          "label": "Latest Drop",
+          "value": "Signal Drift EP is now streaming."
+        },
+        {
+          "label": "Next Broadcast",
+          "value": "Friday · 22:30 ET — Signal test + Q&A"
+        }
       ]
     },
     {
-      "title": "Status",
+      "title": "Contact",
       "items": [
-        "Noise floor nominal",
-        "Next drop: TBD"
+        {
+          "label": "Email",
+          "value": "contact@example.com",
+          "href": "mailto:contact@example.com",
+          "copyable": true
+        },
+        {
+          "label": "Matrix",
+          "value": "@analog:signals.chat",
+          "href": "https://matrix.to/#/@analog:signals.chat",
+          "copyable": true
+        }
+      ]
+    },
+    {
+      "title": "Tip Jar",
+      "items": [
+        {
+          "label": "Ko-fi",
+          "href": "https://ko-fi.com/example"
+        },
+        {
+          "label": "ETH",
+          "value": "0x90fffa2b34be92f6c88df4450bf4429cb12b2300",
+          "copyable": true
+        }
+      ]
+    },
+    {
+      "title": "Socials",
+      "items": [
+        {
+          "label": "Mastodon",
+          "href": "https://fosstodon.org/@analogsignals",
+          "icon": "lucide:radio"
+        },
+        {
+          "label": "YouTube",
+          "href": "https://www.youtube.com/@astrodotbuild",
+          "icon": "lucide:tv"
+        }
+      ]
+    },
+    {
+      "title": "Now Playing",
+      "items": [
+        {
+          "label": "Channel",
+          "value": "Futureshock FM",
+          "note": "Looping from the control room"
+        }
       ]
     }
   ]

--- a/src/data/profileSchema.ts
+++ b/src/data/profileSchema.ts
@@ -10,9 +10,22 @@ export const profileLinkSchema = z.object({
   cta: z.boolean().optional()
 });
 
+export const profileSectionItemSchema = z.union([
+  z.string().min(1, 'Section items cannot be empty.'),
+  z.object({
+    label: z.string().min(1, 'Section item label is required.'),
+    value: z.string().min(1).optional(),
+    href: z.string().min(1).optional(),
+    icon: z.string().min(1).optional(),
+    badge: z.string().min(1).optional(),
+    copyable: z.boolean().optional(),
+    note: z.string().min(1).optional()
+  })
+]);
+
 export const profileSectionSchema = z.object({
   title: z.string().min(1, 'Section title is required.'),
-  items: z.array(z.string().min(1, 'Section items cannot be empty.')).min(
+  items: z.array(profileSectionItemSchema).min(
     1,
     'Sections must include at least one item.'
   )
@@ -30,6 +43,7 @@ export const profileSchema = z.object({
 
 export type ProfileTheme = z.infer<typeof profileThemeSchema>;
 export type ProfileLink = z.infer<typeof profileLinkSchema>;
+export type ProfileSectionItem = z.infer<typeof profileSectionItemSchema>;
 export type ProfileSection = z.infer<typeof profileSectionSchema>;
 export type Profile = z.infer<typeof profileSchema>;
 

--- a/src/lib/qr.ts
+++ b/src/lib/qr.ts
@@ -1,0 +1,57 @@
+import qrcode from 'qrcode-generator';
+
+export interface QrOptions {
+  size?: number;
+  margin?: number;
+  color?: string;
+  background?: string;
+  ariaLabel?: string;
+}
+
+const DEFAULT_ERROR_CORRECTION_LEVEL: Parameters<typeof qrcode>[1] = 'M';
+const MIN_CELL_SIZE = 2;
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+export const createQrSvg = (value: string, options: QrOptions = {}): string => {
+  const normalized = value?.trim() ?? '';
+  const qr = qrcode(0, DEFAULT_ERROR_CORRECTION_LEVEL);
+  qr.addData(normalized || ' ');
+  qr.make();
+
+  const moduleCount = qr.getModuleCount();
+  const margin = Math.max(0, Math.floor(options.margin ?? 8));
+  const requestedSize = Math.max(moduleCount, Math.floor(options.size ?? 160));
+  const cellSize = Math.max(MIN_CELL_SIZE, Math.floor((requestedSize - margin * 2) / moduleCount));
+  const totalSize = cellSize * moduleCount + margin * 2;
+  const color = options.color ?? '#22ff88';
+  const background = options.background ?? 'transparent';
+  const ariaLabel = escapeHtml(options.ariaLabel ?? 'QR code');
+
+  let path = '';
+  for (let row = 0; row < moduleCount; row += 1) {
+    for (let col = 0; col < moduleCount; col += 1) {
+      if (!qr.isDark(row, col)) {
+        continue;
+      }
+
+      const x = margin + col * cellSize;
+      const y = margin + row * cellSize;
+      path += `M${x} ${y}h${cellSize}v${cellSize}h-${cellSize}z`;
+    }
+  }
+
+  const cornerRadius = Math.max(4, Math.floor(cellSize * 1.5));
+  const backgroundRect = `<rect width="${totalSize}" height="${totalSize}" fill="${background}" rx="${cornerRadius}" ry="${cornerRadius}" />`;
+  const qrPath = `<path d="${path}" fill="${color}" />`;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${totalSize} ${totalSize}" role="img" aria-label="${ariaLabel}" shape-rendering="crispEdges">${backgroundRect}${qrPath}</svg>`;
+};
+
+export default createQrSvg;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,6 +9,7 @@ const fallbackProfile: Profile = profileEntry.data;
 
 const year = new Date().getFullYear();
 const lastTuned = new Date().toISOString().slice(0, 10);
+const canonicalUrl = Astro.url?.href ?? Astro.site?.href ?? 'https://biolink.example.com/';
 ---
 
 <BaseLayout title="Analog Signals" description="CRT-inspired biolink hub for creative broadcasts.">
@@ -17,5 +18,6 @@ const lastTuned = new Date().toISOString().slice(0, 10);
     {year}
     {lastTuned}
     fallbackProfile={fallbackProfile}
+    siteUrl={canonicalUrl}
   />
 </BaseLayout>

--- a/tests/unit/LinksApp.test.ts
+++ b/tests/unit/LinksApp.test.ts
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen, within } from "@testing-library/svelte";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import LinksApp from "../../src/components/LinksApp.svelte";
+import type {
+  ResolvedProfile,
+  ResolvedProfileLink,
+  ResolvedProfileSection,
+  ResolvedProfileSectionItem,
+} from "../../src/stores/profileStore";
+
+type SectionInput = [title: string, items: Partial<ResolvedProfileSectionItem>[]];
+
+const buildSection = ([title, items]: SectionInput): ResolvedProfileSection => ({
+  title,
+  items: items.map((item) => ({
+    label: item.label ?? null,
+    value: item.value ?? null,
+    href: item.href ?? null,
+    icon: item.icon ?? null,
+    badge: item.badge ?? null,
+    note: item.note ?? null,
+    copyable: item.copyable ?? false,
+    text: item.text ?? null,
+  })),
+});
+
+const links: ResolvedProfileLink[] = [
+  {
+    label: "Main Site",
+    url: "https://example.com",
+    icon: "lucide:waveform",
+    badge: "LIVE",
+    cta: true,
+  },
+  {
+    label: "Broadcast",
+    url: "https://example.com/radio",
+    icon: "lucide:radio",
+    badge: undefined,
+    cta: false,
+  },
+];
+
+const sections: ResolvedProfileSection[] = [
+  buildSection([
+    "Contact",
+    [
+      {
+        label: "Email",
+        value: "hello@example.com",
+        href: "mailto:hello@example.com",
+        copyable: true,
+      },
+    ],
+  ]),
+  buildSection([
+    "Tip Jar",
+    [
+      {
+        label: "ETH",
+        value: "0x1234",
+        copyable: true,
+      },
+    ],
+  ]),
+];
+
+const sampleProfile: ResolvedProfile = {
+  displayName: "Analog Signals",
+  handle: "analogsignals",
+  avatar: "/avatar.png",
+  bio: "Broadcast lab",
+  theme: "green",
+  links,
+  sections,
+};
+
+describe("LinksApp", () => {
+  let execCommandDescriptor: PropertyDescriptor | undefined;
+  let clipboardDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    execCommandDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
+    clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+
+    if (execCommandDescriptor) {
+      Object.defineProperty(document, "execCommand", execCommandDescriptor);
+    } else {
+      Reflect.deleteProperty(document as unknown as Record<string, unknown>, "execCommand");
+    }
+
+    if (clipboardDescriptor) {
+      Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator as unknown as Record<string, unknown>, "clipboard");
+    }
+  });
+
+  it("renders profile header, links, and QR code", () => {
+    render(LinksApp, { profile: sampleProfile, siteUrl: "https://example.com" });
+
+    expect(screen.getByText("Analog Signals")).toBeVisible();
+    expect(screen.getByText("@analogsignals")).toBeVisible();
+    expect(screen.getByRole("link", { name: /Main Site/i })).toBeVisible();
+    expect(screen.getByRole("img", { name: /QR code/i })).toBeVisible();
+  });
+
+  it("falls back to execCommand when clipboard permissions are unavailable", async () => {
+    const execCommand = vi.fn(() => true);
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+
+    render(LinksApp, { profile: sampleProfile, siteUrl: "https://example.com" });
+
+    const contactSection = screen.getByText(/Reach out/i).closest("article");
+    expect(contactSection).not.toBeNull();
+    if (!contactSection) {
+      return;
+    }
+
+    const sectionUtils = within(contactSection);
+    const copyButton = sectionUtils.getByRole("button", { name: /copy/i });
+
+    await fireEvent.click(copyButton);
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(copyButton).toHaveTextContent(/copied/i);
+
+    vi.runAllTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- add a rich LinksApp window with avatar, CTA link styling, lazy icon loading, copy-to-clipboard controls, and an embedded QR code generator
- expand the profile schema/store and default content to support structured sections for updates, contact info, socials, and tip jar entries
- wire the new window into the faux desktop with mobile maximization, pass the canonical URL, and cover clipboard fallback behaviour with unit tests

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cb06adcb788320bfff80cc22abf927