### PR TITLE
Add manifest-driven plugin system

### DIFF
--- a/.biomeignore
+++ b/.biomeignore
@@ -1,0 +1,5 @@
+/.astro
+/.astro/**
+node_modules/
+dist/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.astro/
+dist/
+.DS_Store
+coverage/
+.idea/
+.vscode/
+

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ GitHub Actions workflows live in `.github/workflows/`:
 - `ci.yml` covers linting, type checking, unit tests, and Playwright.
 - `pages.yml` builds and deploys to GitHub Pages.
 
+## Plugin system
+
+Desktop apps can now be extended via JSON manifests and Svelte modules. Drop files into `public/plugins/` and `src/plugins/` and they appear in the faux taskbar automatically. See [docs/plugins.md](docs/plugins.md) for the schema, sandbox contract, and sample implementations.
+
 ## Accessibility
 
 Playwright integrates `@axe-core/playwright` to keep the homepage free of WCAG 2.1 A/AA violations. Run `pnpm test:e2e` locally to validate before shipping.

--- a/biome.json
+++ b/biome.json
@@ -19,5 +19,16 @@
         "useConst": "error"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": [".astro/**"],
+      "linter": {
+        "enabled": false
+      },
+      "formatter": {
+        "enabled": false
+      }
+    }
+  ]
 }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,105 @@
+# Plugin system
+
+The faux desktop can discover and mount apps without touching core components. Plugins consist of:
+
+- A manifest JSON file in `public/plugins/`.
+- A Svelte module inside `src/plugins/` (for trusted islands) or static assets for sandboxed iframes.
+
+Dropping both files into the repo is enough—`import.meta.glob` picks them up at build time and the taskbar exposes new launchers automatically.
+
+## Manifest schema
+
+Each manifest lives at `public/plugins/<name>.json` and must satisfy the schema below.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | ✅ | Unique slug using lowercase letters, numbers, or `-`. Used as the window id. |
+| `title` | string | ✅ | Display name in window chrome and taskbar. |
+| `description` | string | | Optional blurb for the Start menu tooltip. |
+| `icon` | string | ✅ | Emoji or image path/URL displayed in launchers. |
+| `module` | string | ✅ | Entry point. For `integration: "island"` this is the path to a Svelte module inside `src/plugins`. For `integration: "iframe"` provide an absolute URL or `/`-prefixed path served from `public/`. |
+| `integration` | `'island' \| 'iframe'` | | Defaults to `'island'`. Islands run as Svelte components; iframe plugins are sandboxed. |
+| `defaultBounds` | `{ x, y, width, height }` | ✅ | Initial window position and size. Width/height must be positive. |
+| `minWidth` / `minHeight` | number | | Optional window constraints (pixels). |
+| `maxWidth` / `maxHeight` | number \| null | | Optional maximum size. |
+| `allowClose` / `allowMinimize` / `allowMaximize` | boolean | | Toggle window chrome buttons. Defaults to `true`. |
+| `restoreFocus` | boolean | | Whether the window should grab focus when reopened. Defaults to `true`. |
+| `startOpen` | boolean | | Open the window on load. Defaults to `false`. |
+| `pinned` | boolean | | Show in the taskbar pinned apps row. Defaults to `true`. |
+| `showInStart` | boolean | | Show in the Start menu list. Defaults to `true`. |
+| `sandbox` | object | | Iframe-only settings. Supports `allow` (string for the `sandbox` attribute), `permissions` (array for the iframe `allow` attribute), `allowedOrigins` (array of origins allowed to talk to the host—`"self"` is replaced with the current origin), and `initialHeight` (number of pixels before the iframe reports its size). |
+
+> ⚠️ Validation happens at build time. Invalid manifests are omitted and surfaced in the debug overlay and console so the desktop keeps rendering safely.
+
+### Example manifest (Svelte island)
+
+```json
+{
+  "id": "text-pad",
+  "title": "Text Pad",
+  "description": "Scratch pad for quick notes.",
+  "icon": "📝",
+  "module": "sample/TextPad.svelte",
+  "defaultBounds": { "x": 540, "y": 200, "width": 360, "height": 320 },
+  "minWidth": 320,
+  "minHeight": 240
+}
+```
+
+### Example manifest (sandboxed iframe)
+
+```json
+{
+  "id": "weather",
+  "title": "Weather Radar",
+  "icon": "/plugins/weather/icon.svg",
+  "integration": "iframe",
+  "module": "/plugins/weather/index.html",
+  "defaultBounds": { "x": 400, "y": 180, "width": 480, "height": 360 },
+  "sandbox": {
+    "allow": "allow-scripts allow-same-origin",
+    "permissions": ["fullscreen"],
+    "allowedOrigins": ["self"],
+    "initialHeight": 360
+  }
+}
+```
+
+## Authoring an island plugin
+
+1. Create a Svelte component inside `src/plugins/`. Use any folder structure you like (e.g. `src/plugins/my-tool/MyTool.svelte`).
+2. Reference the module from your manifest using the relative path (for the example above: `"module": "my-tool/MyTool.svelte"`).
+3. Ship any supporting assets alongside the component (imports work the same as other Svelte islands).
+4. Drop the manifest JSON into `public/plugins/`. No additional wiring is required.
+
+Islands are dynamically imported the first time their window is activated. Loading status and errors are surfaced inside the window frame and in the debug overlay.
+
+## Authoring a sandboxed iframe plugin
+
+1. Build the plugin UI as a standalone HTML/JS bundle placed inside `public/plugins/<id>/` (or host it on another origin).
+2. Set `integration` to `"iframe"` and point `module` to the iframe source (absolute URL or `/plugins/...`).
+3. Optional: tune the sandbox options:
+   - `allow`: passed to the iframe `sandbox` attribute. Defaults to `allow-scripts allow-same-origin`.
+   - `permissions`: forwarded to the iframe `allow` attribute (semicolon-delimited).
+   - `allowedOrigins`: whitelist of origins that can exchange `postMessage` traffic with the host. Use `"self"` to refer to the current origin. The iframe origin is always allowed automatically.
+   - `initialHeight`: starting height (px) before the iframe reports its size.
+
+### postMessage contract
+
+The host automatically sends `postMessage({ type: 'biolink-host:init', pluginId })` when the iframe loads. Plugins should answer with `postMessage({ type: 'biolink-plugin:ready' })`. Supported messages from the iframe:
+
+- `biolink-plugin:ready` — marks the iframe as ready and hides the loading overlay.
+- `biolink-plugin:resize` — accepts `{ height: number }` to request a container height in pixels (minimum 120px).
+- `biolink-plugin:error` — accepts `{ message: string }` to display an error state in the window and log via the debug console.
+
+Any message from an unexpected origin is ignored.
+
+## Diagnostics
+
+- Successful manifests appear as launchers in the taskbar and Start menu.
+- Validation failures do not crash the desktop. They are recorded in the debug overlay (toggle with Alt+D or long-press the taskbar) and logged via the in-app console.
+- Window state persists per plugin id using the existing `WindowManager` storage key.
+
+## Sample plugin
+
+The repository ships with `Text Pad`, defined by `public/plugins/text-pad.json` and implemented in `src/plugins/sample/TextPad.svelte`. Use it as a reference implementation when building new islands.

--- a/public/plugins/text-pad.json
+++ b/public/plugins/text-pad.json
@@ -1,0 +1,17 @@
+{
+  "id": "text-pad",
+  "title": "Text Pad",
+  "description": "Scratch pad for quick notes.",
+  "icon": "📝",
+  "module": "sample/TextPad.svelte",
+  "defaultBounds": {
+    "x": 540,
+    "y": 200,
+    "width": 360,
+    "height": 320
+  },
+  "minWidth": 320,
+  "minHeight": 240,
+  "pinned": true,
+  "showInStart": true
+}

--- a/src/components/IframeSandbox.svelte
+++ b/src/components/IframeSandbox.svelte
@@ -1,0 +1,245 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { logger } from '../lib/logger';
+  import type { PluginSandboxOptions } from '../plugins/registry';
+
+  const browser = typeof window !== 'undefined';
+
+  export let pluginId: string;
+  export let title: string;
+  export let src: string;
+  export let sandbox: PluginSandboxOptions = {
+    allow: null,
+    permissions: [],
+    allowedOrigins: [],
+    initialHeight: null
+  };
+
+  let iframeEl: HTMLIFrameElement | null = null;
+  let status: 'loading' | 'ready' | 'error' = 'loading';
+  let statusMessage = 'Loading plugin…';
+  let frameHeight: string | null = null;
+  let hasDynamicHeight = false;
+  let handshakeTimer: ReturnType<typeof window.setTimeout> | null = null;
+  let targetOrigin = '*';
+  const originWhitelist = new Set<string>();
+
+  const MIN_HEIGHT = 120;
+  const HANDSHAKE_TIMEOUT = 8000;
+
+  const clearHandshakeTimer = () => {
+    if (handshakeTimer !== null && browser) {
+      window.clearTimeout(handshakeTimer);
+      handshakeTimer = null;
+    }
+  };
+
+  const scheduleHandshakeTimeout = () => {
+    if (!browser) {
+      return;
+    }
+    clearHandshakeTimer();
+    handshakeTimer = window.setTimeout(() => {
+      if (status === 'ready') {
+        return;
+      }
+      status = 'error';
+      statusMessage = 'Plugin did not acknowledge host handshake.';
+      logger.warn('Plugin handshake timed out', { pluginId, src });
+    }, HANDSHAKE_TIMEOUT);
+  };
+
+  const applyInitialHeight = (options: PluginSandboxOptions) => {
+    if (hasDynamicHeight) {
+      return;
+    }
+    if (typeof options.initialHeight === 'number' && Number.isFinite(options.initialHeight)) {
+      frameHeight = `${Math.max(options.initialHeight, MIN_HEIGHT)}px`;
+    } else {
+      frameHeight = null;
+    }
+  };
+
+  const resolveOrigins = (options: PluginSandboxOptions, moduleSrc: string) => {
+    if (!browser) {
+      return;
+    }
+
+    originWhitelist.clear();
+
+    for (const origin of options.allowedOrigins ?? []) {
+      if (origin === 'self') {
+        originWhitelist.add(window.location.origin);
+        continue;
+      }
+      try {
+        const resolved = new URL(origin, window.location.origin);
+        originWhitelist.add(resolved.origin);
+      } catch (error) {
+        logger.warn('Ignoring invalid sandbox origin', { pluginId, origin, error });
+      }
+    }
+
+    try {
+      const resolved = new URL(moduleSrc, window.location.origin);
+      targetOrigin = resolved.origin;
+      originWhitelist.add(resolved.origin);
+    } catch (error) {
+      targetOrigin = '*';
+      logger.warn('Failed to resolve plugin iframe origin', { pluginId, src: moduleSrc, error });
+    }
+  };
+
+  const postInitMessage = () => {
+    if (!browser || !iframeEl?.contentWindow) {
+      return;
+    }
+    iframeEl.contentWindow.postMessage(
+      {
+        type: 'biolink-host:init',
+        pluginId
+      },
+      targetOrigin
+    );
+  };
+
+  const handleMessage = (event: MessageEvent) => {
+    if (!iframeEl || event.source !== iframeEl.contentWindow) {
+      return;
+    }
+
+    if (originWhitelist.size > 0 && !originWhitelist.has(event.origin)) {
+      logger.warn('Discarding message from unexpected origin', {
+        pluginId,
+        origin: event.origin
+      });
+      return;
+    }
+
+    const payload = event.data;
+    if (!payload || typeof payload !== 'object') {
+      return;
+    }
+
+    const type = (payload as { type?: unknown }).type;
+    if (typeof type !== 'string') {
+      return;
+    }
+
+    switch (type) {
+      case 'biolink-plugin:ready': {
+        clearHandshakeTimer();
+        status = 'ready';
+        statusMessage = '';
+        logger.info('Sandbox plugin ready', { pluginId });
+        break;
+      }
+      case 'biolink-plugin:error': {
+        clearHandshakeTimer();
+        status = 'error';
+        statusMessage =
+          typeof (payload as { message?: unknown }).message === 'string'
+            ? ((payload as { message?: string }).message ?? 'Plugin reported an error.')
+            : 'Plugin reported an error.';
+        logger.error('Sandbox plugin reported an error', { pluginId, message: statusMessage });
+        break;
+      }
+      case 'biolink-plugin:resize': {
+        const height = (payload as { height?: unknown }).height;
+        if (typeof height === 'number' && Number.isFinite(height)) {
+          frameHeight = `${Math.max(height, MIN_HEIGHT)}px`;
+          hasDynamicHeight = true;
+        }
+        break;
+      }
+      default:
+        logger.debug('Unhandled sandbox message', { pluginId, type });
+        break;
+    }
+  };
+
+  const handleLoad = () => {
+    status = 'loading';
+    statusMessage = 'Waiting for plugin…';
+    hasDynamicHeight = false;
+    applyInitialHeight(sandbox);
+    scheduleHandshakeTimeout();
+    postInitMessage();
+  };
+
+  onMount(() => {
+    if (!browser) {
+      return;
+    }
+    resolveOrigins(sandbox, src);
+    applyInitialHeight(sandbox);
+    window.addEventListener('message', handleMessage);
+  });
+
+  onDestroy(() => {
+    if (!browser) {
+      return;
+    }
+    clearHandshakeTimer();
+    window.removeEventListener('message', handleMessage);
+  });
+
+  $: if (browser) {
+    resolveOrigins(sandbox, src);
+  }
+
+  $: applyInitialHeight(sandbox);
+
+  $: const allowAttr = sandbox.allow?.trim();
+  $: const permissionAttr = sandbox.permissions?.length
+    ? sandbox.permissions.join('; ')
+    : undefined;
+</script>
+
+<div class="sandbox" data-state={status}>
+  <iframe
+    bind:this={iframeEl}
+    title={`${title} plugin`}
+    src={src}
+    sandbox={allowAttr ?? 'allow-scripts allow-same-origin'}
+    allow={permissionAttr}
+    referrerpolicy="no-referrer"
+    loading="lazy"
+    on:load={handleLoad}
+    style:height={frameHeight ?? '100%'}
+  ></iframe>
+  {#if status !== 'ready'}
+    <div class="sandbox__status" role="status">{statusMessage}</div>
+  {/if}
+</div>
+
+<style>
+  .sandbox {
+    position: relative;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    align-items: stretch;
+  }
+
+  iframe {
+    flex: 1;
+    border: none;
+    background: transparent;
+  }
+
+  .sandbox__status {
+    position: absolute;
+    inset: 0.5rem;
+    display: grid;
+    place-items: center;
+    font-size: 0.85rem;
+    color: rgb(var(--muted, 180 180 180));
+    background: linear-gradient(145deg, rgb(var(--surface) / 0.9), rgb(var(--surface-glare, 25 25 25) / 0.9));
+    border: 1px dashed rgb(var(--accent) / 0.45);
+    border-radius: 0.75rem;
+    text-align: center;
+    padding: 1rem;
+    pointer-events: none;
+  }
+</style>

--- a/src/components/PluginWindow.svelte
+++ b/src/components/PluginWindow.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { SvelteComponent } from 'svelte';
+  import Window from './Window.svelte';
+  import IframeSandbox from './IframeSandbox.svelte';
+  import { logger } from '../lib/logger';
+  import type { IslandPluginDefinition, PluginDefinition } from '../plugins/registry';
+  import type { WindowPersistentState } from './windowing';
+
+  const browser = typeof window !== 'undefined';
+
+  export let plugin: PluginDefinition;
+
+  let Component: typeof SvelteComponent | null = null;
+  let isLoading = false;
+  let loadError: string | null = null;
+  let hasLoaded = false;
+  let lastPluginId = plugin.id;
+
+  let initialState: WindowPersistentState = {
+    bounds: { ...plugin.defaultBounds },
+    isClosed: !(plugin.startOpen ?? false),
+    isMinimized: false,
+    isMaximized: false,
+    restoreBounds: null
+  };
+
+  $: initialState = {
+    bounds: { ...plugin.defaultBounds },
+    isClosed: !(plugin.startOpen ?? false),
+    isMinimized: false,
+    isMaximized: false,
+    restoreBounds: null
+  };
+
+  $: if (plugin.id !== lastPluginId) {
+    Component = null;
+    loadError = null;
+    hasLoaded = false;
+    isLoading = false;
+    lastPluginId = plugin.id;
+  }
+
+  const ensureComponent = async (definition: IslandPluginDefinition) => {
+    if (!browser || hasLoaded || Component) {
+      return;
+    }
+
+    isLoading = true;
+    loadError = null;
+
+    try {
+      const module = await definition.load();
+      if (!module || typeof module.default !== 'function') {
+        throw new Error('Plugin module does not export a Svelte component.');
+      }
+      Component = module.default;
+      hasLoaded = true;
+      logger.info('Plugin module loaded', { pluginId: definition.id, module: definition.modulePath });
+    } catch (error) {
+      loadError = error instanceof Error ? error.message : 'Unknown plugin loading error.';
+      logger.error('Failed to load plugin module', {
+        pluginId: definition.id,
+        module: definition.modulePath,
+        error
+      });
+    } finally {
+      isLoading = false;
+    }
+  };
+
+  const handleActivate = () => {
+    if (plugin.integration === 'island') {
+      ensureComponent(plugin);
+    }
+  };
+
+  onMount(() => {
+    if (plugin.integration === 'island' && plugin.startOpen) {
+      ensureComponent(plugin);
+    }
+  });
+</script>
+
+<Window
+  id={plugin.id}
+  title={plugin.title}
+  initialBounds={plugin.defaultBounds}
+  minWidth={plugin.minWidth ?? 280}
+  minHeight={plugin.minHeight ?? 180}
+  maxWidth={plugin.maxWidth ?? null}
+  maxHeight={plugin.maxHeight ?? null}
+  closeable={plugin.allowClose}
+  minimizable={plugin.allowMinimize}
+  maximizable={plugin.allowMaximize}
+  restoreFocus={plugin.restoreFocus}
+  initialState={initialState}
+  on:activate={handleActivate}
+>
+  {#if plugin.integration === 'iframe'}
+    <IframeSandbox pluginId={plugin.id} title={plugin.title} src={plugin.iframeSrc} sandbox={plugin.sandbox} />
+  {:else}
+    {#if loadError}
+      <div class="plugin-error" role="alert">Failed to load plugin: {loadError}</div>
+    {:else if Component}
+      <svelte:component this={Component} />
+    {:else if isLoading}
+      <div class="plugin-loading" role="status">Loading {plugin.title}…</div>
+    {:else}
+      <div class="plugin-loading" role="status">Activate to launch {plugin.title}.</div>
+    {/if}
+  {/if}
+</Window>
+
+<style>
+  .plugin-loading,
+  .plugin-error {
+    display: grid;
+    place-items: center;
+    height: 100%;
+    font-size: 0.85rem;
+    text-align: center;
+    padding: 1.5rem;
+  }
+
+  .plugin-error {
+    color: rgb(var(--accent, 160 80 80));
+  }
+</style>

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1,0 +1,283 @@
+import { z } from 'zod';
+import type { SvelteComponent } from 'svelte';
+import type { Bounds } from '../components/windowing';
+
+const boundsSchema = z.object({
+  x: z.number().finite(),
+  y: z.number().finite(),
+  width: z.number().positive(),
+  height: z.number().positive()
+});
+
+const pluginManifestSchema = z
+  .object({
+    id: z
+      .string()
+      .min(1, 'id is required')
+      .regex(/^[a-z0-9-]+$/, 'id must use lowercase letters, numbers, or dashes'),
+    title: z.string().min(1, 'title is required'),
+    description: z.string().optional().default(''),
+    icon: z.string().min(1, 'icon is required'),
+    module: z.string().min(1, 'module is required'),
+    integration: z.enum(['island', 'iframe']).default('island'),
+    defaultBounds: boundsSchema,
+    minWidth: z.number().positive().optional(),
+    minHeight: z.number().positive().optional(),
+    maxWidth: z.number().positive().nullable().optional(),
+    maxHeight: z.number().positive().nullable().optional(),
+    allowClose: z.boolean().optional().default(true),
+    allowMinimize: z.boolean().optional().default(true),
+    allowMaximize: z.boolean().optional().default(true),
+    restoreFocus: z.boolean().optional().default(true),
+    startOpen: z.boolean().optional().default(false),
+    pinned: z.boolean().optional().default(true),
+    showInStart: z.boolean().optional().default(true),
+    sandbox: z
+      .object({
+        allow: z.string().optional(),
+        permissions: z.array(z.string()).optional(),
+        allowedOrigins: z.array(z.string()).optional(),
+        initialHeight: z.number().positive().optional()
+      })
+      .optional()
+  })
+  .superRefine((value, ctx) => {
+    if (value.integration === 'iframe') {
+      const module = value.module.trim();
+      if (!module.startsWith('/') && !/^https?:\/\//.test(module)) {
+        ctx.addIssue({
+          path: ['module'],
+          code: z.ZodIssueCode.custom,
+          message: 'Iframe plugins must provide an absolute URL or a path that begins with "/".'
+        });
+      }
+    } else if (/^https?:\/\//.test(value.module.trim())) {
+      ctx.addIssue({
+        path: ['module'],
+        code: z.ZodIssueCode.custom,
+        message: 'Island plugins must reference modules inside src/plugins (do not use absolute URLs).'
+      });
+    }
+  });
+
+export type PluginManifest = z.infer<typeof pluginManifestSchema>;
+
+export type IconKind = 'glyph' | 'image';
+
+export interface PluginSandboxOptions {
+  allow: string | null;
+  permissions: string[];
+  allowedOrigins: string[];
+  initialHeight: number | null;
+}
+
+interface PluginBaseDefinition {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  iconKind: IconKind;
+  defaultBounds: Bounds;
+  minWidth?: number;
+  minHeight?: number;
+  maxWidth?: number | null;
+  maxHeight?: number | null;
+  allowClose: boolean;
+  allowMinimize: boolean;
+  allowMaximize: boolean;
+  restoreFocus: boolean;
+  startOpen: boolean;
+  pinned: boolean;
+  showInStart: boolean;
+  manifestPath: string;
+}
+
+export interface PluginComponentModule {
+  default: typeof SvelteComponent;
+}
+
+export interface IslandPluginDefinition extends PluginBaseDefinition {
+  integration: 'island';
+  modulePath: string;
+  load: () => Promise<PluginComponentModule>;
+}
+
+export interface IframePluginDefinition extends PluginBaseDefinition {
+  integration: 'iframe';
+  iframeSrc: string;
+  sandbox: PluginSandboxOptions;
+}
+
+export type PluginDefinition = IslandPluginDefinition | IframePluginDefinition;
+
+export interface PluginLoadError {
+  manifestPath: string;
+  summary: string;
+  issues: string[];
+}
+
+type ManifestModule = Record<string, unknown>;
+type ComponentLoader = () => Promise<PluginComponentModule>;
+
+const manifestModules = import.meta.glob('../../public/plugins/**/*.json', {
+  eager: true,
+  import: 'default'
+}) as Record<string, ManifestModule>;
+
+const componentModules = import.meta.glob('./**/*.svelte') as Record<string, ComponentLoader>;
+
+const canonicalizeModulePath = (value: string): string => {
+  const normalized = value.replace(/\\+/g, '/').trim();
+  const withoutDot = normalized.replace(/^\.\/?/, '');
+  if (withoutDot.startsWith('src/plugins/')) {
+    return withoutDot.slice('src/plugins/'.length);
+  }
+  if (withoutDot.startsWith('~/plugins/')) {
+    return withoutDot.slice('~/plugins/'.length);
+  }
+  if (withoutDot.startsWith('plugins/')) {
+    return withoutDot.slice('plugins/'.length);
+  }
+  return withoutDot;
+};
+
+const iconKindFromValue = (value: string): IconKind => {
+  const trimmed = value.trim();
+  if (/^(data:|https?:\/\/)/.test(trimmed)) {
+    return 'image';
+  }
+  if (trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../')) {
+    return 'image';
+  }
+  if (/\.(svg|png|jpe?g|gif|webp|avif)$/i.test(trimmed)) {
+    return 'image';
+  }
+  return 'glyph';
+};
+
+const normalizeManifestPath = (path: string): string => {
+  const normalized = path.replace(/\\+/g, '/');
+  const marker = '/public/';
+  const index = normalized.lastIndexOf(marker);
+  if (index === -1) {
+    return normalized;
+  }
+  return `/${normalized.slice(index + marker.length)}`;
+};
+
+const moduleLoaders = new Map<string, ComponentLoader>();
+
+for (const [key, loader] of Object.entries(componentModules)) {
+  moduleLoaders.set(canonicalizeModulePath(key), loader);
+}
+
+const buildSandboxOptions = (manifest: PluginManifest): PluginSandboxOptions => {
+  const sandbox = manifest.sandbox ?? {};
+  const allow = sandbox.allow?.trim() ?? null;
+  const permissions = Array.isArray(sandbox.permissions)
+    ? sandbox.permissions.filter((item): item is string => typeof item === 'string')
+    : [];
+  const allowedOrigins = Array.isArray(sandbox.allowedOrigins)
+    ? sandbox.allowedOrigins
+        .map((origin) => origin.trim())
+        .filter((origin) => origin.length > 0)
+    : [];
+  const initialHeight = typeof sandbox.initialHeight === 'number' && Number.isFinite(sandbox.initialHeight)
+    ? sandbox.initialHeight
+    : null;
+  return { allow, permissions, allowedOrigins, initialHeight };
+};
+
+const seenIds = new Set<string>();
+
+const definitions: PluginDefinition[] = [];
+const errors: PluginLoadError[] = [];
+
+const formatIssue = (path: (string | number)[], message: string) => {
+  if (!path.length) {
+    return message;
+  }
+  return `${path.join('.')}: ${message}`;
+};
+
+for (const [manifestPath, module] of Object.entries(manifestModules)) {
+  const result = pluginManifestSchema.safeParse(module);
+  if (!result.success) {
+    errors.push({
+      manifestPath: normalizeManifestPath(manifestPath),
+      summary: 'Plugin manifest failed validation',
+      issues: result.error.issues.map((issue) => formatIssue(issue.path, issue.message))
+    });
+    continue;
+  }
+
+  const manifest = result.data;
+  if (seenIds.has(manifest.id)) {
+    errors.push({
+      manifestPath: normalizeManifestPath(manifestPath),
+      summary: `Duplicate plugin id "${manifest.id}"`,
+      issues: [`Another manifest already registered the id "${manifest.id}".`]
+    });
+    continue;
+  }
+
+  const base: PluginBaseDefinition = {
+    id: manifest.id,
+    title: manifest.title,
+    description: manifest.description ?? '',
+    icon: manifest.icon,
+    iconKind: iconKindFromValue(manifest.icon),
+    defaultBounds: { ...manifest.defaultBounds },
+    minWidth: manifest.minWidth,
+    minHeight: manifest.minHeight,
+    maxWidth: manifest.maxWidth ?? null,
+    maxHeight: manifest.maxHeight ?? null,
+    allowClose: manifest.allowClose ?? true,
+    allowMinimize: manifest.allowMinimize ?? true,
+    allowMaximize: manifest.allowMaximize ?? true,
+    restoreFocus: manifest.restoreFocus ?? true,
+    startOpen: manifest.startOpen ?? false,
+    pinned: manifest.pinned ?? true,
+    showInStart: manifest.showInStart ?? true,
+    manifestPath: normalizeManifestPath(manifestPath)
+  };
+
+  if (manifest.integration === 'iframe') {
+    const sandbox = buildSandboxOptions(manifest);
+    const iframeSrc = manifest.module.startsWith('http') || manifest.module.startsWith('/')
+      ? manifest.module
+      : `/${manifest.module.replace(/^\/?/, '')}`;
+
+    definitions.push({
+      ...base,
+      integration: 'iframe',
+      iframeSrc,
+      sandbox
+    });
+    seenIds.add(manifest.id);
+    continue;
+  }
+
+  const moduleKey = canonicalizeModulePath(manifest.module);
+  const loader = moduleLoaders.get(moduleKey);
+
+  if (!loader) {
+    errors.push({
+      manifestPath: normalizeManifestPath(manifestPath),
+      summary: `Plugin module "${manifest.module}" was not found`,
+      issues: ['Ensure the file exists inside src/plugins and the manifest uses a relative path.']
+    });
+    continue;
+  }
+
+  definitions.push({
+    ...base,
+    integration: 'island',
+    modulePath: moduleKey,
+    load: loader
+  });
+  seenIds.add(manifest.id);
+}
+
+export const pluginDefinitions: readonly PluginDefinition[] = definitions;
+export const pluginLoadErrors: readonly PluginLoadError[] = errors;

--- a/src/plugins/sample/TextPad.svelte
+++ b/src/plugins/sample/TextPad.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  let text = '';
+  let savedText = '';
+  let lastSavedAt: Date | null = null;
+  let textArea: HTMLTextAreaElement | null = null;
+
+  const handleSave = () => {
+    savedText = text;
+    lastSavedAt = new Date();
+  };
+
+  const handleClear = () => {
+    text = '';
+    savedText = '';
+    lastSavedAt = null;
+    textArea?.focus();
+  };
+
+  onMount(() => {
+    textArea?.focus();
+  });
+
+  $: characterCount = text.length;
+  $: hasUnsavedChanges = text !== savedText;
+  $: statusLabel = hasUnsavedChanges
+    ? 'Unsaved changes'
+    : lastSavedAt
+      ? `Saved ${lastSavedAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}`
+      : 'Ready';
+</script>
+
+<div class="pad">
+  <header class="pad__header">
+    <h2>Text Pad</h2>
+    <div class="pad__meta">
+      <span>{characterCount} chars</span>
+      <span>{statusLabel}</span>
+    </div>
+  </header>
+  <textarea
+    bind:this={textArea}
+    class="pad__textarea"
+    bind:value={text}
+    placeholder="Write quick notes here…"
+    aria-label="Scratch pad editor"
+  ></textarea>
+  <footer class="pad__footer">
+    <button type="button" class="pad__button" on:click={handleSave} disabled={!hasUnsavedChanges}>
+      Save snapshot
+    </button>
+    <button type="button" class="pad__button pad__button--secondary" on:click={handleClear}>
+      Clear
+    </button>
+  </footer>
+</div>
+
+<style>
+  .pad {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    gap: 1rem;
+    padding: 1rem;
+    color: rgb(var(--text, 220 235 220));
+    font-family: var(--font-sans, system-ui, sans-serif);
+  }
+
+  .pad__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+    text-transform: uppercase;
+    letter-spacing: 0.25em;
+    font-size: 0.7rem;
+  }
+
+  .pad__meta {
+    display: flex;
+    gap: 1rem;
+    font-size: 0.65rem;
+    opacity: 0.75;
+  }
+
+  .pad__textarea {
+    flex: 1;
+    width: 100%;
+    resize: none;
+    padding: 0.9rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgb(var(--accent, 150 200 150) / 0.35);
+    background: rgb(var(--surface, 10 10 10) / 0.75);
+    color: inherit;
+    font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+    font-size: 0.9rem;
+    line-height: 1.5;
+    box-shadow: inset 0 0 0 1px rgb(var(--accent, 150 200 150) / 0.08);
+  }
+
+  .pad__textarea:focus {
+    outline: 2px solid rgb(var(--accent, 150 200 150));
+    outline-offset: 2px;
+  }
+
+  .pad__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+  }
+
+  .pad__button {
+    appearance: none;
+    border: 1px solid rgb(var(--accent, 150 200 150));
+    background: rgb(var(--accent, 150 200 150) / 0.25);
+    color: inherit;
+    padding: 0.5rem 1rem;
+    border-radius: 0.6rem;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: background 160ms ease, border-color 160ms ease, opacity 160ms ease;
+  }
+
+  .pad__button:hover:not(:disabled),
+  .pad__button:focus-visible {
+    background: rgb(var(--accent, 150 200 150) / 0.35);
+    border-color: rgb(var(--accent, 150 200 150));
+    outline: none;
+  }
+
+  .pad__button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .pad__button--secondary {
+    background: transparent;
+    border-color: rgb(var(--accent, 150 200 150) / 0.5);
+  }
+</style>


### PR DESCRIPTION
## Summary
- load plugin manifests from `public/plugins/*.json`, validate schema, and expose definitions with lazy island imports or iframe configs
- add PluginWindow and IframeSandbox components and surface plugin launchers/errors through the desktop and taskbar UI
- document the plugin manifest format, ship a Text Pad sample, and ignore generated Astro outputs for linting

## Testing
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_68cba4432dd4832085e82322d5e4d208