### PR TITLE
Fix reactive declarations in IframeSandbox

### DIFF
--- a/src/components/IframeSandbox.svelte
+++ b/src/components/IframeSandbox.svelte
@@ -23,6 +23,8 @@
   let handshakeTimer: ReturnType<typeof window.setTimeout> | null = null;
   let targetOrigin = '*';
   const originWhitelist = new Set<string>();
+  let allowAttr: string | undefined;
+  let permissionAttr: string | undefined;
 
   const MIN_HEIGHT = 120;
   const HANDSHAKE_TIMEOUT = 8000;
@@ -190,8 +192,8 @@
 
   $: applyInitialHeight(sandbox);
 
-  $: const allowAttr = sandbox.allow?.trim();
-  $: const permissionAttr = sandbox.permissions?.length
+  $: allowAttr = sandbox.allow?.trim();
+  $: permissionAttr = sandbox.permissions?.length
     ? sandbox.permissions.join('; ')
     : undefined;
 </script>


### PR DESCRIPTION
## Summary
- declare reactive iframe attribute variables before use
- update reactive statements to assign values instead of redeclaring constants

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbafaff70c832087a0deacaac18363