### PR TITLE
Add GPU CRT post-processing pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ GitHub Actions workflows live in `.github/workflows/`:
 - `ci.yml` covers linting, type checking, unit tests, and Playwright.
 - `pages.yml` builds and deploys to GitHub Pages.
 
+## CRT rendering pipeline
+
+The screen simulation now renders through a dedicated `<CRTPostFX>` overlay. The component captures the DOM with `html2canvas`,
+uploads the frame to WebGPU (or WebGL2 via PicoGL), and applies scanlines, slot mask, vignette, noise, and optional bloom in
+real time. Pointer events remain routed to the underlying DOM, so links and controls behave identically to the unprocessed view.
+
+- Mode detection prefers WebGPU, falls back to WebGL2, then gracefully disables the GPU canvas and reuses the existing CSS/SVG
+  overlays when neither API is available.
+- Capture frequency throttles automatically and honours `prefers-reduced-motion`, capping the render loop to 30 FPS and
+  disabling temporal noise for motion-sensitive users or hidden tabs.
+- All CRT toggles live in a single Svelte store, which feeds uniforms for the shaders or CSS custom properties. The Debug
+  overlay now surfaces the active render mode and exposes the same controls regardless of backend.
+
 ## Plugin system
 
 Desktop apps can now be extended via JSON manifests and Svelte modules. Drop files into `public/plugins/` and `src/plugins/` and they appear in the faux taskbar automatically. See [docs/plugins.md](docs/plugins.md) for the schema, sandbox contract, and sample implementations.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "@astrojs/tailwind": "^5.1.0",
     "@iconify/svelte": "^5.0.2",
     "astro": "^4.16.19",
+    "html2canvas": "^1.4.1",
     "motion": "^12.23.13",
+    "picogl": "^0.17.9",
     "qrcode-generator": "^2.0.4",
     "svelte": "^5.1.16",
     "zod": "^3.25.8"
@@ -43,6 +45,7 @@
     "@testing-library/svelte": "^5.2.8",
     "@types/node": "^22.8.3",
     "@vitest/coverage-v8": "^3.2.4",
+    "@webgpu/types": "^0.1.65",
     "autoprefixer": "^10.4.21",
     "axe-core": "^4.10.3",
     "jsdom": "^24.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,15 @@ importers:
       astro:
         specifier: ^4.16.19
         version: 4.16.19(@types/node@22.18.5)(rollup@4.50.2)(typescript@5.9.2)
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
       motion:
         specifier: ^12.23.13
         version: 12.23.13
+      picogl:
+        specifier: ^0.17.9
+        version: 0.17.9
       qrcode-generator:
         specifier: ^2.0.4
         version: 2.0.4
@@ -60,6 +66,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.5)(jiti@1.21.7)(jsdom@24.1.3)(yaml@2.8.1))
+      '@webgpu/types':
+        specifier: ^0.1.65
+        version: 0.1.65
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
@@ -1116,6 +1125,9 @@ packages:
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
 
+  '@webgpu/types@0.1.65':
+    resolution: {integrity: sha512-cYrHab4d6wuVvDW5tdsfI6/o6vcLMDe6w2Citd1oS51Xxu2ycLCnVo4fqwujfKWijrZMInTJIKcXxteoy21nVA==}
+
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -1215,6 +1227,10 @@ packages:
 
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   baseline-browser-mapping@2.8.4:
     resolution: {integrity: sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==}
@@ -1353,6 +1369,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -1718,6 +1737,10 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -2249,6 +2272,9 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picogl@0.17.9:
+    resolution: {integrity: sha512-TfqB7jlD5FTO4a/Rp9wnMhVjPA0XZ/xbtLS2f8eHtOmVtIOhFD7Wf0jUL6kDjww3bgF/REEV9oPreBeGvWFlUQ==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -2619,6 +2645,9 @@ packages:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
 
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -2745,6 +2774,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -4078,6 +4110,8 @@ snapshots:
 
   '@vscode/l10n@0.0.18': {}
 
+  '@webgpu/types@0.1.65': {}
+
   acorn@8.15.0: {}
 
   agent-base@7.1.4: {}
@@ -4237,6 +4271,8 @@ snapshots:
 
   base-64@1.0.0: {}
 
+  base64-arraybuffer@1.0.2: {}
+
   baseline-browser-mapping@2.8.4: {}
 
   binary-extensions@2.3.0: {}
@@ -4372,6 +4408,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   css.escape@1.5.1: {}
 
@@ -4786,6 +4826,11 @@ snapshots:
   html-escaper@3.0.3: {}
 
   html-void-elements@3.0.0: {}
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
 
   http-cache-semantics@4.2.0: {}
 
@@ -5468,6 +5513,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picogl@0.17.9: {}
+
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
@@ -5942,6 +5989,10 @@ snapshots:
       glob: 10.4.5
       minimatch: 9.0.5
 
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -6070,6 +6121,10 @@ snapshots:
       requires-port: 1.0.0
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   vfile-location@5.0.3:
     dependencies:

--- a/src/components/CRTPostFX.svelte
+++ b/src/components/CRTPostFX.svelte
@@ -1,0 +1,389 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { crtEffects } from '../stores/crtEffects';
+  import type { CRTEffectsState } from '../stores/crtEffects';
+  import { logger } from '../lib/logger';
+  import { detectRenderMode } from '../lib/crt/detectMode';
+  import {
+    createDomCapture,
+    type DomCaptureController
+  } from '../lib/crt/capture';
+  import { createWebGpuRenderer } from '../lib/crt/webgpuRenderer';
+  import { createWebGl2Renderer } from '../lib/crt/webgl2Renderer';
+  import type { CRTGpuRenderer, CRTRenderMode } from '../lib/crt/types';
+  import { UNIFORM_FLOAT_COUNT } from '../lib/crt/types';
+
+  const BADGE_LABELS: Record<CRTRenderMode, string> = {
+    webgpu: 'WebGPU',
+    webgl2: 'WebGL2',
+    css: 'CSS'
+  };
+
+  let container: HTMLDivElement | null = null;
+  let canvas: HTMLCanvasElement | null = null;
+  let renderMode: CRTRenderMode = 'css';
+  let badgeLabel = BADGE_LABELS.css;
+  let canvasHidden = true;
+
+  let effectState: CRTEffectsState | null = null;
+  let renderer: CRTGpuRenderer | null = null;
+  let domCapture: DomCaptureController | null = null;
+  let reduceMotion = false;
+  let reduceMotionQuery: MediaQueryList | null = null;
+  let motionListener: ((event: MediaQueryListEvent) => void) | null = null;
+
+  const uniforms = new Float32Array(UNIFORM_FLOAT_COUNT);
+
+  let hasTexture = false;
+  let running = false;
+  let rafId = 0;
+  let lastFrame = 0;
+  let frameAccumulator = 0;
+  let frameSamples = 0;
+  let dpr = 1;
+  let viewportWidth = 0;
+  let viewportHeight = 0;
+
+  const updateBadge = () => {
+    const base = BADGE_LABELS[renderMode] ?? renderMode.toUpperCase();
+    badgeLabel = effectState?.plainMode ? `${base} · Plain` : base;
+  };
+
+  const updateCanvasSize = () => {
+    if (!canvas) {
+      return;
+    }
+    dpr = window.devicePixelRatio || 1;
+    viewportWidth = Math.max(1, Math.round(window.innerWidth * dpr));
+    viewportHeight = Math.max(1, Math.round(window.innerHeight * dpr));
+    canvas.width = viewportWidth;
+    canvas.height = viewportHeight;
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
+    uniforms[0] = viewportWidth;
+    uniforms[1] = viewportHeight;
+    uniforms[2] = 1 / viewportWidth;
+    uniforms[3] = 1 / viewportHeight;
+    uniforms[11] = dpr;
+    renderer?.resize(viewportWidth, viewportHeight);
+  };
+
+  const updateEffectUniforms = () => {
+    const state = effectState;
+    const plain = state?.plainMode ?? false;
+    const scanlines = plain || !(state?.scanlines ?? false) ? 0 : state?.intensity.scanlines ?? 0;
+    const glow = plain || !(state?.glow ?? false) ? 0 : state?.intensity.glow ?? 0;
+    const aberration = plain || !(state?.aberration ?? false) ? 0 : state?.intensity.aberration ?? 0;
+    const slotMask = scanlines > 0 ? Math.min(1, 0.35 + scanlines * 0.8) : 0;
+    const vignette = plain ? 0 : 0.35;
+    const noiseBase = plain ? 0 : 0.05;
+    const noise = reduceMotion ? 0 : Math.min(0.18, noiseBase + scanlines * 0.08);
+    const bloomThreshold = plain ? 1 : 0.72;
+    const bloomSoftness = plain ? 0 : 0.65;
+
+    uniforms[5] = scanlines;
+    uniforms[6] = slotMask;
+    uniforms[7] = vignette;
+    uniforms[8] = glow;
+    uniforms[9] = aberration;
+    uniforms[10] = noise;
+    uniforms[12] = bloomThreshold;
+    uniforms[13] = bloomSoftness;
+    updateBadge();
+  };
+
+  const shouldRender = () =>
+    renderMode !== 'css' && !(effectState?.plainMode ?? false) && !document.hidden && hasTexture;
+
+  const step = (now: number) => {
+    if (!running) {
+      return;
+    }
+
+    const delta = now - lastFrame;
+    const targetInterval = reduceMotion ? 1000 / 30 : 0;
+    if (targetInterval > 0 && delta < targetInterval) {
+      rafId = window.requestAnimationFrame(step);
+      return;
+    }
+
+    lastFrame = now;
+    uniforms[4] = now * 0.001;
+    renderer?.render(uniforms);
+
+    frameAccumulator += delta;
+    frameSamples += 1;
+    if (frameAccumulator >= 1000) {
+      const average = frameAccumulator / Math.max(1, frameSamples);
+      logger.debug('CRT postFX frame stats', {
+        mode: renderMode,
+        averageMs: Number(average.toFixed(2))
+      });
+      frameAccumulator = 0;
+      frameSamples = 0;
+    }
+
+    rafId = window.requestAnimationFrame(step);
+  };
+
+  const startLoop = () => {
+    if (running || !renderer || !shouldRender()) {
+      return;
+    }
+    running = true;
+    lastFrame = performance.now();
+    rafId = window.requestAnimationFrame(step);
+  };
+
+  const stopLoop = () => {
+    if (!running) {
+      return;
+    }
+    running = false;
+    window.cancelAnimationFrame(rafId);
+    frameAccumulator = 0;
+    frameSamples = 0;
+  };
+
+  const updateRenderState = () => {
+    updateBadge();
+    const active = renderMode !== 'css' && !(effectState?.plainMode ?? false);
+    canvasHidden = !active || !hasTexture;
+    const pauseCapture = !active || document.hidden;
+    domCapture?.setPaused(pauseCapture);
+
+    if (!active) {
+      stopLoop();
+      return;
+    }
+
+    if (!hasTexture) {
+      domCapture?.trigger();
+      stopLoop();
+      return;
+    }
+
+    if (shouldRender()) {
+      startLoop();
+    }
+  };
+
+  const handleResize = () => {
+    updateCanvasSize();
+    domCapture?.trigger();
+  };
+
+  const handleVisibility = () => {
+    if (document.hidden) {
+      domCapture?.setPaused(true);
+      stopLoop();
+      return;
+    }
+    updateRenderState();
+  };
+
+  const initializeRenderer = async () => {
+    if (!canvas) {
+      return;
+    }
+    updateCanvasSize();
+    renderer =
+      renderMode === 'webgpu' ? await createWebGpuRenderer(canvas) : await createWebGl2Renderer(canvas);
+    renderer.resize(viewportWidth, viewportHeight);
+  };
+
+  onMount(() => {
+    const effectsUnsubscribe = crtEffects.subscribe((value) => {
+      effectState = value;
+      updateEffectUniforms();
+      updateRenderState();
+    });
+
+    const setup = async () => {
+      const detected = await detectRenderMode();
+      renderMode = detected;
+      updateBadge();
+      crtEffects.setRenderMode(detected);
+
+      if (detected === 'css') {
+        canvasHidden = true;
+        logger.info('CRT postFX using CSS/SVG overlays');
+        return;
+      }
+
+      if (typeof window.matchMedia === 'function') {
+        reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+        reduceMotion = reduceMotionQuery.matches;
+      } else {
+        reduceMotionQuery = null;
+        reduceMotion = false;
+      }
+
+      logger.info('CRT postFX renderer initialized', { mode: detected });
+
+      await initializeRenderer();
+      updateEffectUniforms();
+
+      const throttle = reduceMotion ? 160 : 80;
+      domCapture = createDomCapture({
+        root: document.documentElement,
+        throttleMs: throttle,
+        ignore: (element) =>
+          element instanceof HTMLElement && element.dataset?.crtPostfxIgnore === 'true',
+        onCapture: async (frame) => {
+          if (!renderer) {
+            frame.bitmap.close();
+            return;
+          }
+          try {
+            await renderer.updateTexture(frame);
+            hasTexture = true;
+            updateRenderState();
+            if (shouldRender()) {
+              startLoop();
+            }
+          } catch (error) {
+            frame.bitmap.close();
+            logger.warn('CRT postFX texture upload failed', error);
+          }
+        }
+      });
+
+      if (reduceMotionQuery) {
+        domCapture.updateThrottle(reduceMotion ? 160 : 80);
+        updateEffectUniforms();
+        motionListener = (event) => {
+          reduceMotion = event.matches;
+          domCapture?.updateThrottle(reduceMotion ? 160 : 80);
+          updateEffectUniforms();
+          const wasRunning = running;
+          stopLoop();
+          if (wasRunning && shouldRender()) {
+            startLoop();
+          }
+        };
+        if ('addEventListener' in reduceMotionQuery) {
+          reduceMotionQuery.addEventListener('change', motionListener);
+        } else if ('addListener' in reduceMotionQuery) {
+          // @ts-expect-error Safari <16
+          reduceMotionQuery.addListener(motionListener);
+        }
+      } else {
+        updateEffectUniforms();
+      }
+
+      document.addEventListener('visibilitychange', handleVisibility);
+      window.addEventListener('resize', handleResize);
+
+      updateRenderState();
+      if (!document.hidden) {
+        domCapture.captureImmediate().catch((error) => {
+          logger.warn('CRT postFX initial capture failed', error);
+        });
+      }
+    };
+
+    setup().catch((error) => {
+      logger.error('CRT postFX failed to initialize', error);
+      domCapture?.destroy();
+      domCapture = null;
+      renderer?.destroy();
+      renderer = null;
+      hasTexture = false;
+      renderMode = 'css';
+      badgeLabel = BADGE_LABELS.css;
+      canvasHidden = true;
+      crtEffects.setRenderMode('css');
+    });
+
+    return () => {
+      effectsUnsubscribe();
+    };
+  });
+
+  onDestroy(() => {
+    stopLoop();
+    domCapture?.destroy();
+    domCapture = null;
+    renderer?.destroy();
+    renderer = null;
+    if (reduceMotionQuery && motionListener) {
+      if ('removeEventListener' in reduceMotionQuery) {
+        reduceMotionQuery.removeEventListener('change', motionListener);
+      } else if ('removeListener' in reduceMotionQuery) {
+        // @ts-expect-error Safari <16
+        reduceMotionQuery.removeListener(motionListener);
+      }
+    }
+    document.removeEventListener('visibilitychange', handleVisibility);
+    window.removeEventListener('resize', handleResize);
+  });
+</script>
+
+<div
+  class="crt-postfx"
+  bind:this={container}
+  aria-hidden="true"
+  data-mode={renderMode}
+  data-hidden={canvasHidden}
+  data-crt-postfx-ignore="true"
+>
+  <canvas
+    class="crt-postfx__canvas"
+    bind:this={canvas}
+    data-crt-postfx-ignore="true"
+    data-hidden={canvasHidden}
+  ></canvas>
+  <span class="crt-postfx__badge" data-mode={renderMode}>{badgeLabel}</span>
+</div>
+
+<style>
+  .crt-postfx {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    pointer-events: none;
+    display: block;
+  }
+
+  .crt-postfx[data-hidden='true'] {
+    visibility: hidden;
+  }
+
+  .crt-postfx__canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+    pointer-events: none;
+    background-color: black;
+  }
+
+  .crt-postfx__canvas[data-hidden='true'] {
+    opacity: 0;
+  }
+
+  .crt-postfx__badge {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    padding: 0.3rem 0.6rem;
+    font-size: 0.65rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    border-radius: 9999px;
+    background: rgba(16, 36, 26, 0.75);
+    color: rgb(var(--accent));
+    backdrop-filter: blur(6px);
+    pointer-events: none;
+    mix-blend-mode: screen;
+  }
+
+  @media (max-width: 640px) {
+    .crt-postfx__badge {
+      font-size: 0.58rem;
+      top: 0.75rem;
+      right: 0.75rem;
+    }
+  }
+</style>
+

--- a/src/components/DebugOverlay.svelte
+++ b/src/components/DebugOverlay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
-  import { crtEffects, defaultEffectsState, type CRTToggle } from '../stores/crtEffects';
+  import { crtEffects, crtRenderMode, defaultEffectsState, type CRTToggle } from '../stores/crtEffects';
   import { logger, logs } from '../lib/logger';
   import type { PluginLoadError } from '../plugins/registry';
 
@@ -8,6 +8,12 @@
   export let pluginErrors: PluginLoadError[] = [];
 
   type EffectsState = typeof defaultEffectsState;
+
+  const MODE_LABELS: Record<string, string> = {
+    webgpu: 'WebGPU',
+    webgl2: 'WebGL2',
+    css: 'CSS fallback'
+  };
 
   const effectLabels: Record<CRTToggle, string> = {
     scanlines: 'Scanlines',
@@ -37,6 +43,9 @@
 
   let state: EffectsState = cloneState();
   $: state = $crtEffects;
+  let renderMode = 'css';
+  $: renderMode = $crtRenderMode;
+  let renderModeLabel = MODE_LABELS[renderMode] ?? renderMode;
 
   let adjustmentsDisabled = Boolean(state?.plainMode);
   $: adjustmentsDisabled = Boolean(state?.plainMode);
@@ -290,6 +299,7 @@
         <h2>Debug Overlay</h2>
         <div class="debug-panel__meta">
           <span class="debug-panel__fps">Live FPS: {fpsLabel}</span>
+          <span class="debug-panel__mode">Mode: {renderModeLabel}</span>
           <button type="button" class="debug-button subtle" on:click={() => (open = false)}>
             Close
           </button>
@@ -472,6 +482,10 @@
 
   .debug-panel__fps {
     color: rgb(var(--accent-soft));
+  }
+
+  .debug-panel__mode {
+    color: rgb(var(--accent));
   }
 
   .debug-section {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,3 +1,24 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types='astro/client' />
+/// <reference types='@webgpu/types' />
+
+declare module '*.wgsl' {
+  const source: string;
+  export default source;
+}
+
+declare module '*.wgsl?raw' {
+  const source: string;
+  export default source;
+}
+
+declare module '*.glsl' {
+  const source: string;
+  export default source;
+}
+
+declare module '*.glsl?raw' {
+  const source: string;
+  export default source;
+}
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/tailwind.css";
 import CRTCurtain from "../components/CRTCurtain.svelte";
+import CRTPostFX from "../components/CRTPostFX.svelte";
 
 interface Props {
   title?: string;
@@ -34,6 +35,7 @@ const {
         </main>
       </div>
     </CRTCurtain>
+    <CRTPostFX client:load />
   </body>
 </html>
 

--- a/src/lib/crt/capture.ts
+++ b/src/lib/crt/capture.ts
@@ -1,0 +1,211 @@
+import html2canvas from 'html2canvas';
+import { logger } from '../logger';
+import type { CaptureFrame } from './types';
+
+interface DomCaptureOptions {
+  root: HTMLElement;
+  ignore?: (element: Element) => boolean;
+  throttleMs?: number;
+  onCapture: (frame: CaptureFrame) => Promise<void> | void;
+}
+
+export interface DomCaptureController {
+  trigger(): void;
+  captureImmediate(): Promise<void>;
+  setPaused(paused: boolean): void;
+  updateThrottle(value: number): void;
+  destroy(): void;
+}
+
+const DEFAULT_THROTTLE = 80;
+
+export const createDomCapture = ({
+  root,
+  ignore,
+  throttleMs = DEFAULT_THROTTLE,
+  onCapture
+}: DomCaptureOptions): DomCaptureController => {
+  let disposed = false;
+  let paused = false;
+  let scheduled = false;
+  let running = false;
+  let lastCapture = 0;
+  let throttle = throttleMs;
+  let animationLoopHandle = 0;
+  let activeAnimations = 0;
+
+  const ignorePredicate = ignore ?? ((element: Element) => element instanceof HTMLElement && element.dataset.crtPostfxIgnore === 'true');
+
+  const schedule = () => {
+    if (disposed || paused) {
+      return;
+    }
+    if (scheduled) {
+      return;
+    }
+    scheduled = true;
+    window.requestAnimationFrame(async () => {
+      scheduled = false;
+      await capture();
+    });
+  };
+
+  const stopAnimationLoop = () => {
+    if (animationLoopHandle) {
+      window.cancelAnimationFrame(animationLoopHandle);
+      animationLoopHandle = 0;
+    }
+  };
+
+  const animationTick = () => {
+    if (disposed || paused || activeAnimations === 0) {
+      stopAnimationLoop();
+      return;
+    }
+
+    schedule();
+    animationLoopHandle = window.requestAnimationFrame(animationTick);
+  };
+
+  const ensureAnimationLoop = () => {
+    if (animationLoopHandle || activeAnimations === 0 || disposed || paused) {
+      return;
+    }
+    animationLoopHandle = window.requestAnimationFrame(animationTick);
+  };
+
+  const handleMutation: MutationCallback = () => {
+    schedule();
+  };
+
+  const handleAnimationStart = () => {
+    activeAnimations += 1;
+    schedule();
+    ensureAnimationLoop();
+  };
+
+  const handleAnimationStop = () => {
+    activeAnimations = Math.max(0, activeAnimations - 1);
+    schedule();
+    if (activeAnimations === 0) {
+      stopAnimationLoop();
+    }
+  };
+
+  const handleResize = () => {
+    schedule();
+  };
+
+  const observer = new MutationObserver(handleMutation);
+  observer.observe(root, {
+    attributes: true,
+    childList: true,
+    characterData: true,
+    subtree: true
+  });
+
+  window.addEventListener('resize', handleResize);
+  document.addEventListener('animationstart', handleAnimationStart, true);
+  document.addEventListener('animationiteration', schedule, true);
+  document.addEventListener('animationend', handleAnimationStop, true);
+  document.addEventListener('animationcancel', handleAnimationStop, true);
+  document.addEventListener('transitionstart', handleAnimationStart, true);
+  document.addEventListener('transitionend', handleAnimationStop, true);
+  document.addEventListener('transitioncancel', handleAnimationStop, true);
+
+  const capture = async (force = false) => {
+    if (disposed || paused) {
+      return;
+    }
+
+    const now = performance.now();
+    if (!force && running) {
+      return;
+    }
+
+    if (!force && now - lastCapture < throttle) {
+      schedule();
+      return;
+    }
+
+    running = true;
+
+    try {
+      const dpr = window.devicePixelRatio || 1;
+      const canvas = await html2canvas(root, {
+        backgroundColor: null,
+        useCORS: true,
+        logging: false,
+        scale: dpr,
+        ignoreElements: (element) => ignorePredicate(element)
+      });
+
+      const bitmap = await createImageBitmap(canvas);
+      await onCapture({
+        bitmap,
+        width: canvas.width,
+        height: canvas.height,
+        dpr
+      });
+    } catch (error) {
+      logger.warn('CRT postFX capture failed', error);
+    } finally {
+      lastCapture = performance.now();
+      running = false;
+    }
+  };
+
+  const trigger = () => {
+    if (disposed) {
+      return;
+    }
+    schedule();
+  };
+
+  const captureImmediate = async () => {
+    await capture(true);
+  };
+
+  const setPaused = (value: boolean) => {
+    if (disposed) {
+      return;
+    }
+    paused = value;
+    if (!paused) {
+      schedule();
+      ensureAnimationLoop();
+    } else {
+      stopAnimationLoop();
+    }
+  };
+
+  const updateThrottle = (value: number) => {
+    throttle = Math.max(16, Math.floor(value));
+  };
+
+  const destroy = () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    observer.disconnect();
+    window.removeEventListener('resize', handleResize);
+    document.removeEventListener('animationstart', handleAnimationStart, true);
+    document.removeEventListener('animationiteration', schedule, true);
+    document.removeEventListener('animationend', handleAnimationStop, true);
+    document.removeEventListener('animationcancel', handleAnimationStop, true);
+    document.removeEventListener('transitionstart', handleAnimationStart, true);
+    document.removeEventListener('transitionend', handleAnimationStop, true);
+    document.removeEventListener('transitioncancel', handleAnimationStop, true);
+    stopAnimationLoop();
+  };
+
+  return {
+    trigger,
+    captureImmediate,
+    setPaused,
+    updateThrottle,
+    destroy
+  };
+};
+

--- a/src/lib/crt/detectMode.ts
+++ b/src/lib/crt/detectMode.ts
@@ -1,0 +1,34 @@
+import type { CRTRenderMode } from './types';
+
+export const detectRenderMode = async (): Promise<CRTRenderMode> => {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return 'css';
+  }
+
+  if ('gpu' in navigator && navigator.gpu) {
+    try {
+      const adapter = await navigator.gpu.requestAdapter();
+      if (adapter) {
+        return 'webgpu';
+      }
+    } catch (error) {
+      console.warn('[CRTPostFX] WebGPU adapter request failed', error);
+    }
+  }
+
+  try {
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('webgl2', { antialias: false, depth: false });
+    if (context) {
+      context.getExtension('EXT_color_buffer_float');
+      context.getExtension('OES_texture_float_linear');
+      context.getExtension('EXT_float_blend');
+      return 'webgl2';
+    }
+  } catch (error) {
+    console.warn('[CRTPostFX] WebGL2 context request failed', error);
+  }
+
+  return 'css';
+};
+

--- a/src/lib/crt/shaders/crt.frag.glsl
+++ b/src/lib/crt/shaders/crt.frag.glsl
@@ -1,0 +1,91 @@
+#version 300 es
+precision highp float;
+
+uniform sampler2D uScene;
+uniform vec2 uResolution;
+uniform vec2 uInvResolution;
+uniform float uTime;
+uniform float uScanlineIntensity;
+uniform float uSlotMaskIntensity;
+uniform float uVignetteStrength;
+uniform float uBloomIntensity;
+uniform float uAberrationStrength;
+uniform float uNoiseIntensity;
+uniform float uDevicePixelRatio;
+uniform float uBloomThreshold;
+uniform float uBloomSoftness;
+
+in vec2 vUv;
+out vec4 fragColor;
+
+vec2 clampUv(vec2 value) {
+  return clamp(value, vec2(0.0), vec2(1.0));
+}
+
+void main() {
+  vec2 uv = vUv;
+  vec3 color = texture(uScene, clampUv(uv)).rgb;
+
+  if (uAberrationStrength > 0.0001) {
+    vec2 center = uv - vec2(0.5);
+    vec2 offset = center * uAberrationStrength * 1.35;
+    float redSample = texture(uScene, clampUv(uv + offset)).r;
+    float blueSample = texture(uScene, clampUv(uv - offset)).b;
+    color.r = mix(color.r, redSample, min(0.85, uAberrationStrength * 0.85));
+    color.b = mix(color.b, blueSample, min(0.85, uAberrationStrength * 0.85));
+  }
+
+  if (uScanlineIntensity > 0.0001) {
+    float line = sin((uv.y * uResolution.y) / uDevicePixelRatio * 3.14159265);
+    float mask = mix(1.0, 0.55 + 0.45 * line * line, uScanlineIntensity);
+    color *= mask;
+  }
+
+  if (uSlotMaskIntensity > 0.0001) {
+    int triad = int(floor((uv.x * uResolution.x) / uDevicePixelRatio)) % 3;
+    vec3 slotMask = vec3(0.35);
+    if (triad == 0) {
+      slotMask.r = 1.0;
+    } else if (triad == 1) {
+      slotMask.g = 1.0;
+    } else {
+      slotMask.b = 1.0;
+    }
+    color *= mix(vec3(1.0), slotMask, uSlotMaskIntensity);
+  }
+
+  if (uBloomIntensity > 0.0001) {
+    vec3 accum = vec3(0.0);
+    vec2 taps[5];
+    taps[0] = vec2(0.0);
+    taps[1] = vec2(uInvResolution.x * 2.0, 0.0);
+    taps[2] = vec2(-uInvResolution.x * 2.0, 0.0);
+    taps[3] = vec2(0.0, uInvResolution.y * 2.0);
+    taps[4] = vec2(0.0, -uInvResolution.y * 2.0);
+
+    for (int i = 0; i < 5; i++) {
+      vec2 sampleUv = clampUv(uv + taps[i]);
+      accum += texture(uScene, sampleUv).rgb;
+    }
+    accum /= 5.0;
+    float luminance = dot(accum, vec3(0.2126, 0.7152, 0.0722));
+    float weight = smoothstep(uBloomThreshold, 1.0, luminance);
+    color = mix(color, accum, weight * uBloomIntensity * uBloomSoftness);
+  }
+
+  if (uVignetteStrength > 0.0001) {
+    float dist = distance(uv, vec2(0.5));
+    float vig = smoothstep(0.75, 0.45, dist);
+    color *= mix(1.0, vig, uVignetteStrength);
+  }
+
+  if (uNoiseIntensity > 0.0001) {
+    float noise = fract(sin(dot(uv * uResolution, vec2(12.9898, 78.233)) + uTime * 12.345) * 43758.5453);
+    float grain = (noise - 0.5) * uNoiseIntensity;
+    color += vec3(grain);
+  }
+
+  color = clamp(color, 0.0, 1.0);
+  fragColor = vec4(color, 1.0);
+}
+

--- a/src/lib/crt/shaders/crt.vert.glsl
+++ b/src/lib/crt/shaders/crt.vert.glsl
@@ -1,0 +1,20 @@
+#version 300 es
+precision highp float;
+
+out vec2 vUv;
+
+void main() {
+  vec2 positions[3];
+  positions[0] = vec2(-1.0, -1.0);
+  positions[1] = vec2(-1.0, 3.0);
+  positions[2] = vec2(3.0, -1.0);
+
+  vec2 uvs[3];
+  uvs[0] = vec2(0.0, 0.0);
+  uvs[1] = vec2(0.0, 2.0);
+  uvs[2] = vec2(2.0, 0.0);
+
+  gl_Position = vec4(positions[gl_VertexID], 0.0, 1.0);
+  vUv = uvs[gl_VertexID];
+}
+

--- a/src/lib/crt/shaders/crt.wgsl
+++ b/src/lib/crt/shaders/crt.wgsl
@@ -1,0 +1,123 @@
+struct Uniforms {
+  resolution: vec4<f32>;
+  factorsA: vec4<f32>;
+  factorsB: vec4<f32>;
+  factorsC: vec4<f32>;
+};
+
+@group(0) @binding(0) var linearSampler: sampler;
+@group(0) @binding(1) var sceneTexture: texture_2d<f32>;
+@group(0) @binding(2) var<uniform> uniforms: Uniforms;
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>;
+  @location(0) uv: vec2<f32>;
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
+  var positions = array<vec2<f32>, 3>(
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>(-1.0, 3.0),
+    vec2<f32>(3.0, -1.0)
+  );
+
+  var uvs = array<vec2<f32>, 3>(
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(0.0, 2.0),
+    vec2<f32>(2.0, 0.0)
+  );
+
+  var output: VertexOutput;
+  output.position = vec4<f32>(positions[vertexIndex], 0.0, 1.0);
+  output.uv = uvs[vertexIndex];
+  return output;
+}
+
+fn clampUv(value: vec2<f32>) -> vec2<f32> {
+  return clamp(value, vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 1.0));
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+  let uv = input.uv;
+  let resolution = uniforms.resolution.xy;
+  let invResolution = uniforms.resolution.zw;
+  let time = uniforms.factorsA.x;
+  let scanlineIntensity = uniforms.factorsA.y;
+  let slotMaskIntensity = uniforms.factorsA.z;
+  let vignetteStrength = uniforms.factorsA.w;
+  let bloomIntensity = uniforms.factorsB.x;
+  let aberrationStrength = uniforms.factorsB.y;
+  let noiseIntensity = uniforms.factorsB.z;
+  let devicePixelRatio = uniforms.factorsB.w;
+  let bloomThreshold = uniforms.factorsC.x;
+  let bloomSoftness = uniforms.factorsC.y;
+
+  var color = textureSampleLevel(sceneTexture, linearSampler, clampUv(uv), 0.0).rgb;
+
+  if (aberrationStrength > 0.0001) {
+    let center = uv - vec2<f32>(0.5, 0.5);
+    let offset = center * aberrationStrength * 1.35;
+    let redUv = clampUv(uv + offset);
+    let blueUv = clampUv(uv - offset);
+    let redSample = textureSampleLevel(sceneTexture, linearSampler, redUv, 0.0).r;
+    let blueSample = textureSampleLevel(sceneTexture, linearSampler, blueUv, 0.0).b;
+    color.r = mix(color.r, redSample, min(0.85, aberrationStrength * 0.85));
+    color.b = mix(color.b, blueSample, min(0.85, aberrationStrength * 0.85));
+  }
+
+  if (scanlineIntensity > 0.0001) {
+    let line = sin((uv.y * resolution.y) / devicePixelRatio * 3.14159265);
+    let mask = mix(1.0, 0.55 + 0.45 * line * line, scanlineIntensity);
+    color = color * mask;
+  }
+
+  if (slotMaskIntensity > 0.0001) {
+    let triad = i32(floor((uv.x * resolution.x) / devicePixelRatio)) % 3;
+    var slotMask = vec3<f32>(0.35, 0.35, 0.35);
+    if (triad == 0) {
+      slotMask.x = 1.0;
+    } else if (triad == 1) {
+      slotMask.y = 1.0;
+    } else {
+      slotMask.z = 1.0;
+    }
+    color = color * mix(vec3<f32>(1.0, 1.0, 1.0), slotMask, slotMaskIntensity);
+  }
+
+  if (bloomIntensity > 0.0001) {
+    var accum = vec3<f32>(0.0, 0.0, 0.0);
+    let taps = array<vec2<f32>, 5>(
+      vec2<f32>(0.0, 0.0),
+      vec2<f32>(invResolution.x * 2.0, 0.0),
+      vec2<f32>(-invResolution.x * 2.0, 0.0),
+      vec2<f32>(0.0, invResolution.y * 2.0),
+      vec2<f32>(0.0, -invResolution.y * 2.0)
+    );
+    for (var i = 0u; i < taps.length(); i = i + 1u) {
+      let sampleUv = clampUv(uv + taps[i]);
+      accum = accum + textureSampleLevel(sceneTexture, linearSampler, sampleUv, 0.0).rgb;
+    }
+    accum = accum / f32(taps.length());
+    let luminance = dot(accum, vec3<f32>(0.2126, 0.7152, 0.0722));
+    let weight = smoothstep(bloomThreshold, 1.0, luminance);
+    color = mix(color, accum, weight * bloomIntensity * bloomSoftness);
+  }
+
+  if (vignetteStrength > 0.0001) {
+    let dist = distance(uv, vec2<f32>(0.5, 0.5));
+    let vig = smoothstep(0.75, 0.45, dist);
+    color = color * mix(1.0, vig, vignetteStrength);
+  }
+
+  if (noiseIntensity > 0.0001) {
+    let noise = fract(sin(dot(uv * resolution.xy, vec2<f32>(12.9898, 78.233)) + time * 12.345) * 43758.5453);
+    let grain = (noise - 0.5) * noiseIntensity;
+    color = color + vec3<f32>(grain, grain, grain);
+  }
+
+  color = clamp(color, vec3<f32>(0.0, 0.0, 0.0), vec3<f32>(1.0, 1.0, 1.0));
+  return vec4<f32>(color, 1.0);
+}
+

--- a/src/lib/crt/types.ts
+++ b/src/lib/crt/types.ts
@@ -1,0 +1,35 @@
+export type CRTRenderMode = 'webgpu' | 'webgl2' | 'css';
+
+export interface UniformState {
+  width: number;
+  height: number;
+  time: number;
+  scanlines: number;
+  slotMask: number;
+  vignette: number;
+  bloom: number;
+  aberration: number;
+  noise: number;
+  dpr: number;
+  bloomThreshold: number;
+  bloomSoftness: number;
+}
+
+export interface CaptureFrame {
+  bitmap: ImageBitmap;
+  width: number;
+  height: number;
+  dpr: number;
+}
+
+export const UNIFORM_FLOAT_COUNT = 16;
+
+export interface CRTGpuRenderer {
+  readonly mode: Exclude<CRTRenderMode, 'css'>;
+  init(canvas: HTMLCanvasElement): Promise<void>;
+  render(uniforms: Float32Array): void;
+  resize(width: number, height: number): void;
+  updateTexture(frame: CaptureFrame): Promise<void>;
+  destroy(): void;
+}
+

--- a/src/lib/crt/webgl2Renderer.ts
+++ b/src/lib/crt/webgl2Renderer.ts
@@ -1,0 +1,183 @@
+import PicoGL from 'picogl';
+import vertSource from './shaders/crt.vert.glsl?raw';
+import fragSource from './shaders/crt.frag.glsl?raw';
+import type { CaptureFrame, CRTGpuRenderer } from './types';
+
+type PicoUniformValue = number | readonly number[];
+
+interface PicoTexture {
+  bind(unit: number): PicoTexture;
+  data(source: TexImageSource): void;
+  delete(): void;
+}
+
+interface PicoDrawCall {
+  primitive(mode: number): PicoDrawCall;
+  texture(name: string, texture: PicoTexture): PicoDrawCall;
+  uniform(name: string, value: PicoUniformValue): PicoDrawCall;
+  draw(): void;
+  delete(): void;
+}
+
+interface PicoTextureOptions {
+  data: TexImageSource | ArrayBufferView | null;
+  minFilter: number;
+  magFilter: number;
+  wrapS: number;
+  wrapT: number;
+}
+
+interface PicoApp {
+  clearColor(r: number, g: number, b: number, a: number): PicoApp;
+  createProgram(vertexSource: string, fragmentSource: string): unknown;
+  createVertexArray(): unknown;
+  createTexture2D(width: number, height: number, options: PicoTextureOptions): PicoTexture;
+  createDrawCall(program: unknown, vertexArray: unknown): PicoDrawCall;
+  viewport(x: number, y: number, width: number, height: number): PicoApp;
+  clear(): void;
+  gl: WebGL2RenderingContext;
+  TRIANGLES: number;
+}
+
+export class WebGl2Renderer implements CRTGpuRenderer {
+  readonly mode = 'webgl2' as const;
+
+  private app: PicoApp | null = null;
+  private drawCall: PicoDrawCall | null = null;
+  private texture: PicoTexture | null = null;
+  private canvas: HTMLCanvasElement | null = null;
+  private width = 0;
+  private height = 0;
+
+  async init(canvas: HTMLCanvasElement) {
+    const context = canvas.getContext('webgl2', {
+      alpha: true,
+      antialias: false,
+      depth: false,
+      stencil: false,
+      preserveDrawingBuffer: false,
+      premultipliedAlpha: true
+    });
+
+    if (!context) {
+      throw new Error('Unable to create WebGL2 context');
+    }
+
+    this.canvas = canvas;
+    const app = PicoGL.createApp(canvas, { context }) as PicoApp;
+    this.app = app.clearColor(0, 0, 0, 1);
+
+    const program = this.app.createProgram(vertSource, fragSource);
+    const vertexArray = this.app.createVertexArray();
+    this.texture = this.app
+      .createTexture2D(1, 1, {
+        data: null,
+        minFilter: PicoGL.LINEAR,
+        magFilter: PicoGL.LINEAR,
+        wrapS: PicoGL.CLAMP_TO_EDGE,
+        wrapT: PicoGL.CLAMP_TO_EDGE
+      })
+      .bind(0);
+
+    this.drawCall = this.app
+      .createDrawCall(program, vertexArray)
+      .primitive(this.app.TRIANGLES)
+      .texture('uScene', this.texture)
+      .uniform('uResolution', [1, 1])
+      .uniform('uInvResolution', [1, 1])
+      .uniform('uTime', 0)
+      .uniform('uScanlineIntensity', 0)
+      .uniform('uSlotMaskIntensity', 0)
+      .uniform('uVignetteStrength', 0)
+      .uniform('uBloomIntensity', 0)
+      .uniform('uAberrationStrength', 0)
+      .uniform('uNoiseIntensity', 0)
+      .uniform('uDevicePixelRatio', 1)
+      .uniform('uBloomThreshold', 0.7)
+      .uniform('uBloomSoftness', 0.6);
+  }
+
+  async updateTexture(frame: CaptureFrame) {
+    if (!this.app || !this.texture) {
+      frame.bitmap.close();
+      return;
+    }
+
+    const needsResize = this.width !== frame.width || this.height !== frame.height;
+    if (needsResize) {
+      this.texture = this.app
+        .createTexture2D(frame.width, frame.height, {
+          data: null,
+          minFilter: PicoGL.LINEAR,
+          magFilter: PicoGL.LINEAR,
+          wrapS: PicoGL.CLAMP_TO_EDGE,
+          wrapT: PicoGL.CLAMP_TO_EDGE
+        })
+        .bind(0);
+      this.drawCall?.texture('uScene', this.texture);
+      this.width = frame.width;
+      this.height = frame.height;
+    }
+
+    this.texture.data(frame.bitmap);
+    frame.bitmap.close();
+  }
+
+  render(uniforms: Float32Array) {
+    if (!this.app || !this.drawCall || !this.canvas) {
+      return;
+    }
+
+    const width = uniforms[0];
+    const height = uniforms[1];
+
+    this.app.viewport(0, 0, width, height);
+    this.drawCall
+      .uniform('uResolution', [uniforms[0], uniforms[1]])
+      .uniform('uInvResolution', [uniforms[2], uniforms[3]])
+      .uniform('uTime', uniforms[4])
+      .uniform('uScanlineIntensity', uniforms[5])
+      .uniform('uSlotMaskIntensity', uniforms[6])
+      .uniform('uVignetteStrength', uniforms[7])
+      .uniform('uBloomIntensity', uniforms[8])
+      .uniform('uAberrationStrength', uniforms[9])
+      .uniform('uNoiseIntensity', uniforms[10])
+      .uniform('uDevicePixelRatio', uniforms[11])
+      .uniform('uBloomThreshold', uniforms[12])
+      .uniform('uBloomSoftness', uniforms[13]);
+
+    this.app.clear();
+    this.drawCall.draw();
+  }
+
+  resize(width: number, height: number) {
+    if (!this.canvas) {
+      return;
+    }
+    this.canvas.width = width;
+    this.canvas.height = height;
+  }
+
+  destroy() {
+    if (this.texture) {
+      this.texture.delete();
+      this.texture = null;
+    }
+    if (this.drawCall) {
+      this.drawCall.delete();
+      this.drawCall = null;
+    }
+    if (this.app) {
+      this.app.gl.getExtension('WEBGL_lose_context')?.loseContext();
+      this.app = null;
+    }
+    this.canvas = null;
+  }
+}
+
+export const createWebGl2Renderer = async (canvas: HTMLCanvasElement) => {
+  const renderer = new WebGl2Renderer();
+  await renderer.init(canvas);
+  return renderer;
+};
+

--- a/src/lib/crt/webgpuRenderer.ts
+++ b/src/lib/crt/webgpuRenderer.ts
@@ -1,0 +1,193 @@
+import shaderSource from './shaders/crt.wgsl?raw';
+import type { CaptureFrame, CRTGpuRenderer } from './types';
+import { UNIFORM_FLOAT_COUNT } from './types';
+
+interface TextureSize {
+  width: number;
+  height: number;
+}
+
+export class WebGpuRenderer implements CRTGpuRenderer {
+  readonly mode = 'webgpu' as const;
+
+  private device: GPUDevice | null = null;
+  private context: GPUCanvasContext | null = null;
+  private pipeline: GPURenderPipeline | null = null;
+  private sampler: GPUSampler | null = null;
+  private uniformBuffer: GPUBuffer | null = null;
+  private bindGroup: GPUBindGroup | null = null;
+  private texture: GPUTexture | null = null;
+  private textureSize: TextureSize | null = null;
+  private canvas: HTMLCanvasElement | null = null;
+  private format: GPUTextureFormat | null = null;
+
+  async init(canvas: HTMLCanvasElement) {
+    if (!navigator.gpu) {
+      throw new Error('WebGPU unavailable');
+    }
+
+    this.canvas = canvas;
+
+    const adapter = await navigator.gpu.requestAdapter();
+    if (!adapter) {
+      throw new Error('WebGPU adapter not found');
+    }
+
+    this.device = await adapter.requestDevice();
+    this.context = canvas.getContext('webgpu');
+
+    if (!this.context) {
+      throw new Error('Unable to create WebGPU canvas context');
+    }
+
+    this.format = navigator.gpu.getPreferredCanvasFormat();
+    this.context.configure({
+      device: this.device,
+      format: this.format,
+      alphaMode: 'premultiplied'
+    });
+
+    const module = this.device.createShaderModule({ code: shaderSource });
+    this.pipeline = this.device.createRenderPipeline({
+      layout: 'auto',
+      vertex: { module, entryPoint: 'vs_main' },
+      fragment: {
+        module,
+        entryPoint: 'fs_main',
+        targets: [
+          {
+            format: this.format
+          }
+        ]
+      }
+    });
+
+    this.uniformBuffer = this.device.createBuffer({
+      size: UNIFORM_FLOAT_COUNT * Float32Array.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+
+    this.sampler = this.device.createSampler({
+      magFilter: 'linear',
+      minFilter: 'linear',
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'clamp-to-edge'
+    });
+  }
+
+  private updateBindGroup() {
+    if (!this.device || !this.pipeline || !this.uniformBuffer || !this.sampler || !this.texture) {
+      return;
+    }
+
+    const layout = this.pipeline.getBindGroupLayout(0);
+    this.bindGroup = this.device.createBindGroup({
+      layout,
+      entries: [
+        {
+          binding: 0,
+          resource: this.sampler
+        },
+        {
+          binding: 1,
+          resource: this.texture.createView()
+        },
+        {
+          binding: 2,
+          resource: { buffer: this.uniformBuffer }
+        }
+      ]
+    });
+  }
+
+  async updateTexture(frame: CaptureFrame) {
+    if (!this.device) {
+      return;
+    }
+
+    const needsResize = !this.textureSize ||
+      this.textureSize.width !== frame.width ||
+      this.textureSize.height !== frame.height;
+
+    if (needsResize) {
+      this.texture?.destroy();
+      this.texture = this.device.createTexture({
+        size: { width: frame.width, height: frame.height },
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST
+      });
+      this.textureSize = { width: frame.width, height: frame.height };
+      this.updateBindGroup();
+    }
+
+    if (!this.texture) {
+      frame.bitmap.close();
+      return;
+    }
+
+    this.device.queue.copyExternalImageToTexture(
+      { source: frame.bitmap },
+      { texture: this.texture },
+      { width: frame.width, height: frame.height }
+    );
+
+    frame.bitmap.close();
+  }
+
+  render(uniforms: Float32Array) {
+    if (!this.device || !this.context || !this.pipeline || !this.uniformBuffer || !this.bindGroup || !this.format) {
+      return;
+    }
+
+    this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms.buffer, uniforms.byteOffset, uniforms.byteLength);
+
+    const currentTexture = this.context.getCurrentTexture();
+    const encoder = this.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: currentTexture.createView(),
+          loadOp: 'clear',
+          storeOp: 'store',
+          clearValue: { r: 0, g: 0, b: 0, a: 1 }
+        }
+      ]
+    });
+
+    pass.setPipeline(this.pipeline);
+    pass.setBindGroup(0, this.bindGroup);
+    pass.draw(3, 1, 0, 0);
+    pass.end();
+
+    this.device.queue.submit([encoder.finish()]);
+  }
+
+  resize(width: number, height: number) {
+    if (!this.canvas) {
+      return;
+    }
+    this.canvas.width = width;
+    this.canvas.height = height;
+  }
+
+  destroy() {
+    this.texture?.destroy();
+    this.texture = null;
+    this.textureSize = null;
+    this.uniformBuffer?.destroy();
+    this.uniformBuffer = null;
+    (this.device as (GPUDevice & { destroy?: () => void }) | null)?.destroy?.();
+    this.device = null;
+    this.context = null;
+    this.pipeline = null;
+    this.bindGroup = null;
+    this.sampler = null;
+  }
+}
+
+export const createWebGpuRenderer = async (canvas: HTMLCanvasElement) => {
+  const renderer = new WebGpuRenderer();
+  await renderer.init(canvas);
+  return renderer;
+};
+

--- a/src/types/picogl.d.ts
+++ b/src/types/picogl.d.ts
@@ -1,0 +1,2 @@
+declare module 'picogl';
+


### PR DESCRIPTION
## Summary
- add a CRTPostFX overlay that captures the DOM, auto-detects GPU support, and drives WebGPU/WebGL2 post-processing shaders
- create shared CRT pipeline utilities (mode detection, html2canvas capture throttle, shader implementations) and wire them into the existing effects/debug tooling
- document the rendering pipeline and add required dependencies and typings for WebGPU/html2canvas/picogl

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cbb10b4d10832080cae79ef1ac278e