### PR TITLE
Fix WebGPU shader compilation and GPU texture setup

### DIFF
--- a/src/lib/crt/capture.ts
+++ b/src/lib/crt/capture.ts
@@ -137,7 +137,7 @@ export const createDomCapture = ({
         useCORS: true,
         logging: false,
         scale: dpr,
-        ignoreElements: (element) => ignorePredicate(element)
+        ignoreElements: (element: Element) => ignorePredicate(element)
       });
 
       const bitmap = await createImageBitmap(canvas);

--- a/src/lib/crt/shaders/crt.wgsl
+++ b/src/lib/crt/shaders/crt.wgsl
@@ -1,8 +1,8 @@
 struct Uniforms {
-  resolution: vec4<f32>;
-  factorsA: vec4<f32>;
-  factorsB: vec4<f32>;
-  factorsC: vec4<f32>;
+  resolution: vec4<f32>,
+  factorsA: vec4<f32>,
+  factorsB: vec4<f32>,
+  factorsC: vec4<f32>,
 };
 
 @group(0) @binding(0) var linearSampler: sampler;
@@ -10,8 +10,8 @@ struct Uniforms {
 @group(0) @binding(2) var<uniform> uniforms: Uniforms;
 
 struct VertexOutput {
-  @builtin(position) position: vec4<f32>;
-  @location(0) uv: vec2<f32>;
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
 };
 
 @vertex

--- a/src/lib/crt/webgpuRenderer.ts
+++ b/src/lib/crt/webgpuRenderer.ts
@@ -44,7 +44,8 @@ export class WebGpuRenderer implements CRTGpuRenderer {
     this.context.configure({
       device: this.device,
       format: this.format,
-      alphaMode: 'premultiplied'
+      alphaMode: 'premultiplied',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_DST
     });
 
     const module = this.device.createShaderModule({ code: shaderSource });
@@ -114,7 +115,10 @@ export class WebGpuRenderer implements CRTGpuRenderer {
       this.texture = this.device.createTexture({
         size: { width: frame.width, height: frame.height },
         format: 'rgba8unorm',
-        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST
+        usage:
+          GPUTextureUsage.TEXTURE_BINDING |
+          GPUTextureUsage.COPY_DST |
+          GPUTextureUsage.RENDER_ATTACHMENT
       });
       this.textureSize = { width: frame.width, height: frame.height };
       this.updateBindGroup();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     },
     "types": [
       "astro/client",
-      "vite/client"
+      "vite/client",
+      "@webgpu/types"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary
- update the CRT WGSL shader structs to the current WGSL field syntax so Chrome can compile the module
- configure the WebGPU renderer to request swapchain textures with COPY_DST/RENDER_ATTACHMENT usage and give captured textures the same capability
- include WebGPU types in the TS config and tighten capture ignores to keep type-checking green

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cbd1b829cc8320ad99d29db34fb580