### PR TITLE
Refine CRT pipeline and document next steps

### DIFF
--- a/NEXT_AGENT.md
+++ b/NEXT_AGENT.md
@@ -1,0 +1,18 @@
+# Next Agent Notes
+
+## Current State
+- GPU renderers now expect forward/inverse LUTs. WebGPU computes them via `crtLut.wgsl`; WebGL2 consumes worker-generated LUTs and uploads them as RG16F textures.
+- `CRTPostFX.svelte` integrates the LUT controller, event proxy, synthetic cursor uniforms, and adaptive capture throttling. Capture stats and logging hooks are in place but not yet validated against performance targets.
+- Event proxy dispatches hit-tested pointer, wheel, click, and context-menu events back into the DOM, updating cursor uniforms and pointer activity callbacks.
+
+## Follow-ups / Validation
+- Exercise both WebGPU and WebGL2 paths in a browser to ensure shaders compile, LUT generation produces correct distortion, and pointer remapping error stays within spec (≤0.3 px mean / ≤0.8 px P95). Pay special attention to DPR > 1.
+- Confirm CSS fallback remains visually correct when GPU modes are disabled (`crtEffects.applyDocumentEffects`). Ensure overlays stay inert while GPU modes are active.
+- Verify the synthetic cursor rendering matches expected pointer types and button states, and that bloom attenuation via `cursorMeta.y` behaves correctly when dragging.
+- Measure capture and render performance: drag interactions should throttle captures to ~30–45 FPS (`getDragThrottle`), idle mode should coast at low FPS, and bloom taps stay within budget. Adjust throttles or bloom taps if frame pacing misses the targets.
+- Test event proxy focus handling, multi-touch, wheel, double click, and context menu routing (especially when canvas toggles pointer-events during hit-tests).
+- Check worker bundling in the build (Vite) so `lutWorker.ts` loads correctly in production.
+
+## Known Gaps
+- No automated tests or manual validation have been run since the renderer refactor; run a smoke test across supported browsers/devices before shipping.
+- Logging (`logger.debug/info`) is wired but thresholds for aggregation (e.g., 15 captures, 30 proxy samples) may need tuning once real metrics are observed.

--- a/src/components/CRTPostFX.svelte
+++ b/src/components/CRTPostFX.svelte
@@ -1,16 +1,24 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import { crtEffects } from '../stores/crtEffects';
-  import type { CRTEffectsState } from '../stores/crtEffects';
+  import type { CRTEffectsState, CRTModePreference } from '../stores/crtEffects';
   import { logger } from '../lib/logger';
-  import { detectRenderMode } from '../lib/crt/detectMode';
   import {
     createDomCapture,
+    type CaptureStats,
     type DomCaptureController
   } from '../lib/crt/capture';
   import { createWebGpuRenderer } from '../lib/crt/webgpuRenderer';
   import { createWebGl2Renderer } from '../lib/crt/webgl2Renderer';
+  import {
+    createEventProxy,
+    type CursorState,
+    type EventProxyController,
+    type PointerActivityState
+  } from '../lib/crt/eventProxy';
+  import { createLutController } from '../lib/crt/lutController';
   import type { CRTGpuRenderer, CRTRenderMode } from '../lib/crt/types';
+  import type { LutResult } from '../lib/crt/geometryMath';
   import { UNIFORM_FLOAT_COUNT } from '../lib/crt/types';
 
   const BADGE_LABELS: Record<CRTRenderMode, string> = {
@@ -19,85 +27,263 @@
     css: 'CSS'
   };
 
+  const RESOLUTION_OFFSET = 0;
+  const TIMING_OFFSET = 4;
+  const EFFECTS_OFFSET = 8;
+  const BLOOM_OFFSET = 12;
+  const CSS_OFFSET = 16;
+  const CURSOR_STATE_OFFSET = 20;
+  const CURSOR_META_OFFSET = 24;
+
+  const POINTER_INDEX: Record<string, number> = {
+    mouse: 0,
+    touch: 1,
+    pen: 2
+  };
+
   let container: HTMLDivElement | null = null;
   let canvas: HTMLCanvasElement | null = null;
+
   let renderMode: CRTRenderMode = 'css';
   let badgeLabel = BADGE_LABELS.css;
   let canvasHidden = true;
+  let interactive = false;
 
   let effectState: CRTEffectsState | null = null;
   let renderer: CRTGpuRenderer | null = null;
   let domCapture: DomCaptureController | null = null;
+  let eventProxy: EventProxyController | null = null;
+  const lutController = createLutController();
+  let currentLut: LutResult | null = null;
+
+  const uniforms = new Float32Array(UNIFORM_FLOAT_COUNT);
+
   let reduceMotion = false;
   let reduceMotionQuery: MediaQueryList | null = null;
   let motionListener: ((event: MediaQueryListEvent) => void) | null = null;
-
-  const uniforms = new Float32Array(UNIFORM_FLOAT_COUNT);
 
   let hasTexture = false;
   let running = false;
   let rafId = 0;
   let lastFrame = 0;
-  let frameAccumulator = 0;
-  let frameSamples = 0;
+
   let dpr = 1;
-  let viewportWidth = 0;
-  let viewportHeight = 0;
+  let cssWidth = 1;
+  let cssHeight = 1;
+
+  let pointerDown = false;
+
+  let captureDurationAccumulator = 0;
+  let captureSamples = 0;
+  let proxyLatencyAccumulator = 0;
+  let proxyLatencySamples = 0;
+  let fpsAccumulator = 0;
+  let fpsSamples = 0;
+
+  let availableWebGPU = false;
+  let availableWebGL2 = false;
+  let detectionComplete = false;
+  let requestedPreference: CRTModePreference = 'auto';
+  let switchingMode = false;
+  let pendingModeCheck = false;
+  let destroyed = false;
+
+  const geometryParams = { width: 1, height: 1, dpr: 1, k1: 0, k2: 0 };
+  let geometryRevision = 0;
+  let geometryDirty = true;
+
+  const setVec4 = (offset: number, a: number, b: number, c: number, d: number) => {
+    uniforms[offset] = a;
+    uniforms[offset + 1] = b;
+    uniforms[offset + 2] = c;
+    uniforms[offset + 3] = d;
+  };
+
+  const pointerIndex = (type: string) => POINTER_INDEX[type] ?? 0;
+
+  const getIdleThrottle = () => (reduceMotion ? 180 : 120);
+  const getDragThrottle = () => (reduceMotion ? 34 : 24);
+
+  const setCanvasInteractionEnabled = (enabled: boolean) => {
+    if (!canvas) {
+      return;
+    }
+    canvas.style.pointerEvents = enabled ? 'auto' : 'none';
+    canvas.style.cursor = enabled ? 'none' : '';
+  };
 
   const updateBadge = () => {
     const base = BADGE_LABELS[renderMode] ?? renderMode.toUpperCase();
     badgeLabel = effectState?.plainMode ? `${base} · Plain` : base;
   };
 
-  const updateCanvasSize = () => {
-    if (!canvas) {
+  const applyBarrelCoefficients = () => {
+    const state = effectState;
+    const enabled = Boolean(state && !state.plainMode && state.barrel);
+    let k1 = 0;
+    let k2 = 0;
+    if (enabled) {
+      const intensity = state?.intensity.barrel ?? 0;
+      const curvature = Math.min(1.25, intensity * 260);
+      k1 = -0.22 * curvature;
+      k2 = -0.09 * curvature * curvature;
+    }
+    geometryParams.k1 = k1;
+    geometryParams.k2 = k2;
+    uniforms[BLOOM_OFFSET + 2] = k1;
+    uniforms[BLOOM_OFFSET + 3] = k2;
+  };
+
+  const scheduleGeometryUpdate = () => {
+    if (!renderer || renderMode === 'css') {
+      geometryDirty = true;
       return;
     }
-    dpr = window.devicePixelRatio || 1;
-    viewportWidth = Math.max(1, Math.round(window.innerWidth * dpr));
-    viewportHeight = Math.max(1, Math.round(window.innerHeight * dpr));
-    canvas.width = viewportWidth;
-    canvas.height = viewportHeight;
-    canvas.style.width = '100%';
-    canvas.style.height = '100%';
-    uniforms[0] = viewportWidth;
-    uniforms[1] = viewportHeight;
-    uniforms[2] = 1 / viewportWidth;
-    uniforms[3] = 1 / viewportHeight;
-    uniforms[11] = dpr;
-    renderer?.resize(viewportWidth, viewportHeight);
+    geometryDirty = false;
+    const params = { ...geometryParams };
+    const version = ++geometryRevision;
+
+    const run = async () => {
+      try {
+        if (!renderer) {
+          return;
+        }
+        if (renderer.mode === 'webgl2') {
+          const lut = await lutController.request(params);
+          if (geometryRevision !== version || !renderer || renderer.mode !== 'webgl2') {
+            return;
+          }
+          currentLut = lut;
+          eventProxy?.updateLut(lut);
+          await renderer.updateGeometry(params, lut);
+        } else {
+          await renderer.updateGeometry(params);
+          const lut = await lutController.request(params);
+          if (geometryRevision !== version) {
+            return;
+          }
+          currentLut = lut;
+          eventProxy?.updateLut(lut);
+        }
+      } catch (error) {
+        if (!destroyed) {
+          logger.warn('CRT postFX LUT update failed', error);
+        }
+      }
+    };
+
+    void run();
   };
 
   const updateEffectUniforms = () => {
     const state = effectState;
     const plain = state?.plainMode ?? false;
-    const scanlines = plain || !(state?.scanlines ?? false) ? 0 : state?.intensity.scanlines ?? 0;
-    const glow = plain || !(state?.glow ?? false) ? 0 : state?.intensity.glow ?? 0;
-    const aberration = plain || !(state?.aberration ?? false) ? 0 : state?.intensity.aberration ?? 0;
-    const slotMask = scanlines > 0 ? Math.min(1, 0.35 + scanlines * 0.8) : 0;
+    const scanlines = plain || !(state?.scanlines ?? false) ? 0 : state.intensity.scanlines;
+    const glow = plain || !(state?.glow ?? false) ? 0 : state.intensity.glow;
+    const aberration = plain || !(state?.aberration ?? false) ? 0 : state.intensity.aberration;
+    const slotMask = scanlines > 0 ? Math.min(1, 0.35 + scanlines * 0.85) : 0;
     const vignette = plain ? 0 : 0.35;
+    const baseBloom = plain ? 0 : glow;
     const noiseBase = plain ? 0 : 0.05;
     const noise = reduceMotion ? 0 : Math.min(0.18, noiseBase + scanlines * 0.08);
-    const bloomThreshold = plain ? 1 : 0.72;
-    const bloomSoftness = plain ? 0 : 0.65;
+    const threshold = plain ? 1 : 0.7;
+    const softness = plain ? 0.1 : 0.65;
 
-    uniforms[5] = scanlines;
-    uniforms[6] = slotMask;
-    uniforms[7] = vignette;
-    uniforms[8] = glow;
-    uniforms[9] = aberration;
-    uniforms[10] = noise;
-    uniforms[12] = bloomThreshold;
-    uniforms[13] = bloomSoftness;
+    uniforms[TIMING_OFFSET + 1] = scanlines;
+    uniforms[TIMING_OFFSET + 2] = slotMask;
+    uniforms[TIMING_OFFSET + 3] = vignette;
+    uniforms[EFFECTS_OFFSET + 0] = baseBloom;
+    uniforms[EFFECTS_OFFSET + 1] = aberration;
+    uniforms[EFFECTS_OFFSET + 2] = noise;
+    uniforms[BLOOM_OFFSET + 0] = threshold;
+    uniforms[BLOOM_OFFSET + 1] = softness;
+
+    applyBarrelCoefficients();
+    geometryDirty = true;
+    if (renderer && renderMode !== 'css') {
+      scheduleGeometryUpdate();
+    }
     updateBadge();
+  };
+
+  const updateCanvasSize = () => {
+    if (!canvas) {
+      return;
+    }
+    const nextDpr = window.devicePixelRatio || 1;
+    const nextCssWidth = Math.max(1, Math.round(window.innerWidth));
+    const nextCssHeight = Math.max(1, Math.round(window.innerHeight));
+    const deviceWidth = Math.max(1, Math.round(nextCssWidth * nextDpr));
+    const deviceHeight = Math.max(1, Math.round(nextCssHeight * nextDpr));
+
+    dpr = nextDpr;
+    cssWidth = nextCssWidth;
+    cssHeight = nextCssHeight;
+
+    setVec4(RESOLUTION_OFFSET, deviceWidth, deviceHeight, 1 / deviceWidth, 1 / deviceHeight);
+    uniforms[EFFECTS_OFFSET + 3] = dpr;
+    setVec4(CSS_OFFSET, cssWidth, cssHeight, 1 / cssWidth, 1 / cssHeight);
+
+    geometryParams.width = cssWidth;
+    geometryParams.height = cssHeight;
+    geometryParams.dpr = dpr;
+
+    renderer?.resize(deviceWidth, deviceHeight, cssWidth, cssHeight);
+    geometryDirty = true;
+  };
+
+  const logCaptureDuration = (duration: number) => {
+    captureDurationAccumulator += duration;
+    captureSamples += 1;
+    if (captureSamples >= 15) {
+      const average = captureDurationAccumulator / captureSamples;
+      logger.debug('CRT postFX capture stats', {
+        mode: renderMode,
+        avgMs: Number(average.toFixed(2)),
+        samples: captureSamples
+      });
+      captureDurationAccumulator = 0;
+      captureSamples = 0;
+    }
+  };
+
+  const logProxyLatency = (value: number) => {
+    proxyLatencyAccumulator += value;
+    proxyLatencySamples += 1;
+    if (proxyLatencySamples >= 30) {
+      const average = proxyLatencyAccumulator / proxyLatencySamples;
+      logger.debug('CRT postFX proxy latency', {
+        mode: renderMode,
+        avgMs: Number(average.toFixed(2)),
+        samples: proxyLatencySamples
+      });
+      proxyLatencyAccumulator = 0;
+      proxyLatencySamples = 0;
+    }
+  };
+
+  const logFrameTime = (delta: number) => {
+    fpsAccumulator += delta;
+    fpsSamples += 1;
+    if (fpsAccumulator >= 1000 && fpsSamples > 0) {
+      const average = fpsAccumulator / fpsSamples;
+      const fps = 1000 / average;
+      logger.debug('CRT postFX frame stats', {
+        mode: renderMode,
+        fps: Number(fps.toFixed(1)),
+        frameMs: Number(average.toFixed(2))
+      });
+      fpsAccumulator = 0;
+      fpsSamples = 0;
+    }
   };
 
   const shouldRender = () =>
     renderMode !== 'css' &&
+    renderer !== null &&
+    hasTexture &&
     !(effectState?.plainMode ?? false) &&
-    typeof document !== 'undefined' &&
-    !document.hidden &&
-    hasTexture;
+    !(typeof document !== 'undefined' && document.hidden);
 
   const step = (now: number) => {
     if (!running) {
@@ -105,27 +291,16 @@
     }
 
     const delta = now - lastFrame;
-    const targetInterval = reduceMotion ? 1000 / 30 : 0;
-    if (targetInterval > 0 && delta < targetInterval) {
+    const minInterval = reduceMotion ? 1000 / 30 : 0;
+    if (minInterval > 0 && delta < minInterval) {
       rafId = window.requestAnimationFrame(step);
       return;
     }
 
     lastFrame = now;
-    uniforms[4] = now * 0.001;
+    uniforms[TIMING_OFFSET + 0] = now * 0.001;
     renderer?.render(uniforms);
-
-    frameAccumulator += delta;
-    frameSamples += 1;
-    if (frameAccumulator >= 1000) {
-      const average = frameAccumulator / Math.max(1, frameSamples);
-      logger.debug('CRT postFX frame stats', {
-        mode: renderMode,
-        averageMs: Number(average.toFixed(2))
-      });
-      frameAccumulator = 0;
-      frameSamples = 0;
-    }
+    logFrameTime(delta);
 
     rafId = window.requestAnimationFrame(step);
   };
@@ -145,22 +320,26 @@
     }
     running = false;
     window.cancelAnimationFrame(rafId);
-    frameAccumulator = 0;
-    frameSamples = 0;
+    fpsAccumulator = 0;
+    fpsSamples = 0;
   };
 
   const updateRenderState = () => {
     updateBadge();
     const active = renderMode !== 'css' && !(effectState?.plainMode ?? false);
+    interactive = active;
     canvasHidden = !active || !hasTexture;
-    const pauseCapture =
-      !active || (typeof document !== 'undefined' ? document.hidden : true);
+
+    const pauseCapture = !active || (typeof document !== 'undefined' ? document.hidden : true);
     domCapture?.setPaused(pauseCapture);
 
     if (!active) {
       stopLoop();
+      setCanvasInteractionEnabled(false);
       return;
     }
+
+    setCanvasInteractionEnabled(true);
 
     if (!hasTexture) {
       domCapture?.trigger();
@@ -173,8 +352,68 @@
     }
   };
 
+  const handlePointerActivity = (state: PointerActivityState) => {
+    pointerDown = state.pointerDown;
+    uniforms[CURSOR_META_OFFSET + 1] = pointerDown ? 0.55 : 1;
+    domCapture?.updateThrottle(pointerDown ? getDragThrottle() : getIdleThrottle());
+    if (pointerDown) {
+      domCapture?.trigger();
+    }
+    updateRenderState();
+  };
+
+  const handleCursorUpdate = (state: CursorState) => {
+    uniforms[CURSOR_STATE_OFFSET + 0] = state.domX;
+    uniforms[CURSOR_STATE_OFFSET + 1] = state.domY;
+    uniforms[CURSOR_STATE_OFFSET + 2] = state.visible ? 1 : 0;
+    uniforms[CURSOR_STATE_OFFSET + 3] = state.buttons;
+    uniforms[CURSOR_META_OFFSET + 0] = pointerIndex(state.pointerType);
+    if (pointerDown) {
+      domCapture?.trigger();
+    }
+  };
+
+  const handleCapture = async (frame: CaptureFrame, stats: CaptureStats) => {
+    logCaptureDuration(stats.duration);
+    if (!renderer) {
+      frame.bitmap.close();
+      return;
+    }
+
+    try {
+      await renderer.updateTexture(frame);
+      hasTexture = true;
+
+      const captureCssWidth = Math.max(1, Math.round(frame.width / (frame.dpr || 1)));
+      const captureCssHeight = Math.max(1, Math.round(frame.height / (frame.dpr || 1)));
+      if (captureCssWidth !== cssWidth || captureCssHeight !== cssHeight) {
+        cssWidth = captureCssWidth;
+        cssHeight = captureCssHeight;
+        setVec4(CSS_OFFSET, cssWidth, cssHeight, 1 / cssWidth, 1 / cssHeight);
+        geometryParams.width = cssWidth;
+        geometryParams.height = cssHeight;
+        const deviceWidth = Math.max(1, Math.round(cssWidth * dpr));
+        const deviceHeight = Math.max(1, Math.round(cssHeight * dpr));
+        renderer.resize(deviceWidth, deviceHeight, cssWidth, cssHeight);
+        geometryDirty = true;
+      }
+
+      updateRenderState();
+      if (shouldRender()) {
+        startLoop();
+      }
+      if (geometryDirty) {
+        scheduleGeometryUpdate();
+      }
+    } catch (error) {
+      frame.bitmap.close();
+      logger.warn('CRT postFX texture upload failed', error);
+    }
+  };
+
   const handleResize = () => {
     updateCanvasSize();
+    scheduleGeometryUpdate();
     domCapture?.trigger();
   };
 
@@ -185,142 +424,277 @@
       return;
     }
     updateRenderState();
+    if (!hasTexture) {
+      domCapture?.trigger();
+    }
   };
 
-  const initializeRenderer = async () => {
+  const teardownGpu = () => {
+    domCapture?.destroy();
+    domCapture = null;
+    eventProxy?.destroy();
+    eventProxy = null;
+    stopLoop();
+    renderer?.destroy();
+    renderer = null;
+    hasTexture = false;
+    currentLut = null;
+    geometryRevision += 1;
+    geometryDirty = true;
+    pointerDown = false;
+    uniforms[CURSOR_STATE_OFFSET + 2] = 0;
+    uniforms[CURSOR_META_OFFSET + 1] = 1;
+    setCanvasInteractionEnabled(false);
+  };
+
+  const initializeGpu = async (mode: Exclude<CRTRenderMode, 'css'>) => {
     if (!canvas) {
+      throw new Error('Canvas unavailable');
+    }
+
+    teardownGpu();
+
+    renderer = mode === 'webgpu' ? await createWebGpuRenderer(canvas) : await createWebGl2Renderer(canvas);
+    renderMode = mode;
+    hasTexture = false;
+
+    updateCanvasSize();
+    updateEffectUniforms();
+    scheduleGeometryUpdate();
+
+    eventProxy = createEventProxy({
+      canvas,
+      getLut: () =>
+        currentLut
+          ? { width: currentLut.width, height: currentLut.height, data: currentLut.inverse }
+          : null,
+      onCursor: handleCursorUpdate,
+      onActivity: handlePointerActivity,
+      logLatency: (value) => logProxyLatency(value)
+    });
+
+    if (currentLut) {
+      eventProxy.updateLut(currentLut);
+    }
+
+    domCapture = createDomCapture({
+      root: document.documentElement,
+      throttleMs: getIdleThrottle(),
+      ignore: (element) =>
+        element instanceof HTMLElement && element.dataset?.crtPostfxIgnore === 'true',
+      onCapture: handleCapture
+    });
+
+    domCapture.updateThrottle(pointerDown ? getDragThrottle() : getIdleThrottle());
+    domCapture.setPaused(typeof document !== 'undefined' ? document.hidden : true);
+
+    canvasHidden = true;
+    updateRenderState();
+
+    if (typeof document !== 'undefined' && !document.hidden) {
+      domCapture
+        .captureImmediate()
+        .catch((error) => logger.warn('CRT postFX initial capture failed', error));
+    }
+  };
+
+  const chooseMode = (preference: CRTModePreference): CRTRenderMode => {
+    if (preference === 'css') {
+      return 'css';
+    }
+    if (preference === 'webgpu') {
+      if (availableWebGPU) {
+        return 'webgpu';
+      }
+      if (availableWebGL2) {
+        return 'webgl2';
+      }
+      return 'css';
+    }
+    if (preference === 'webgl2') {
+      return availableWebGL2 ? 'webgl2' : 'css';
+    }
+    if (availableWebGPU) {
+      return 'webgpu';
+    }
+    if (availableWebGL2) {
+      return 'webgl2';
+    }
+    return 'css';
+  };
+
+  const switchToMode = async (target: CRTRenderMode) => {
+    if (target === renderMode) {
+      if (geometryDirty && renderer && renderMode !== 'css') {
+        scheduleGeometryUpdate();
+      }
+      updateRenderState();
       return;
     }
-    updateCanvasSize();
-    renderer =
-      renderMode === 'webgpu' ? await createWebGpuRenderer(canvas) : await createWebGl2Renderer(canvas);
-    renderer.resize(viewportWidth, viewportHeight);
+
+    if (target === 'css') {
+      teardownGpu();
+      renderMode = 'css';
+      crtEffects.setRenderMode('css');
+      canvasHidden = true;
+      updateRenderState();
+      return;
+    }
+
+    try {
+      await initializeGpu(target);
+      crtEffects.setRenderMode(target);
+      logger.info('CRT postFX renderer ready', { mode: target });
+      scheduleGeometryUpdate();
+    } catch (error) {
+      logger.error('CRT postFX failed to enable GPU mode', error);
+      teardownGpu();
+      renderMode = 'css';
+      crtEffects.setRenderMode('css');
+      canvasHidden = true;
+    }
+
+    updateRenderState();
+  };
+
+  const ensureMode = () => {
+    if (!detectionComplete || !canvas || destroyed) {
+      return;
+    }
+    const target = chooseMode(requestedPreference);
+    if (target === renderMode && !(geometryDirty && renderer && renderMode !== 'css')) {
+      updateRenderState();
+      return;
+    }
+    if (switchingMode) {
+      pendingModeCheck = true;
+      return;
+    }
+    switchingMode = true;
+    switchToMode(target)
+      .catch((error) => logger.error('CRT postFX mode switch failed', error))
+      .finally(() => {
+        switchingMode = false;
+        if (pendingModeCheck) {
+          pendingModeCheck = false;
+          ensureMode();
+        }
+      });
+  };
+
+  const detectCapabilities = async () => {
+    availableWebGPU = false;
+    availableWebGL2 = false;
+
+    if (typeof navigator !== 'undefined' && 'gpu' in navigator && navigator.gpu) {
+      try {
+        const adapter = await navigator.gpu.requestAdapter();
+        availableWebGPU = Boolean(adapter);
+      } catch (error) {
+        logger.warn('CRT postFX WebGPU detection failed', error);
+      }
+    }
+
+    if (typeof document !== 'undefined') {
+      try {
+        const testCanvas = document.createElement('canvas');
+        const context = testCanvas.getContext('webgl2', { antialias: false, depth: false, stencil: false });
+        if (context) {
+          availableWebGL2 = true;
+          context.getExtension('EXT_color_buffer_float');
+          context.getExtension('OES_texture_float_linear');
+        }
+      } catch (error) {
+        logger.warn('CRT postFX WebGL2 detection failed', error);
+      }
+    }
+
+    detectionComplete = true;
+    logger.info('CRT postFX capabilities', { webgpu: availableWebGPU, webgl2: availableWebGL2 });
+  };
+
+  const setupReduceMotion = () => {
+    if (typeof window.matchMedia === 'function') {
+      reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+      reduceMotion = reduceMotionQuery.matches;
+      motionListener = (event) => {
+        reduceMotion = event.matches;
+        domCapture?.updateThrottle(pointerDown ? getDragThrottle() : getIdleThrottle());
+        updateEffectUniforms();
+        if (running) {
+          stopLoop();
+          startLoop();
+        }
+      };
+      if ('addEventListener' in reduceMotionQuery) {
+        reduceMotionQuery.addEventListener('change', motionListener);
+      } else if ('addListener' in reduceMotionQuery) {
+        // @ts-expect-error Legacy Safari
+        reduceMotionQuery.addListener(motionListener);
+      }
+    } else {
+      reduceMotionQuery = null;
+      reduceMotion = false;
+    }
   };
 
   onMount(() => {
-    const effectsUnsubscribe = crtEffects.subscribe((value) => {
+    setVec4(RESOLUTION_OFFSET, 1, 1, 1, 1);
+    setVec4(TIMING_OFFSET, 0, 0, 0, 0);
+    setVec4(EFFECTS_OFFSET, 0, 0, 0, 1);
+    setVec4(BLOOM_OFFSET, 0.7, 0.6, 0, 0);
+    setVec4(CSS_OFFSET, 1, 1, 1, 1);
+    setVec4(CURSOR_STATE_OFFSET, 0, 0, 0, 0);
+    setVec4(CURSOR_META_OFFSET, 0, 1, 0, 0);
+
+    const unsubscribe = crtEffects.subscribe((value) => {
       effectState = value;
+      requestedPreference = value.modePreference ?? 'auto';
       updateEffectUniforms();
+      ensureMode();
       updateRenderState();
     });
 
-    const setup = async () => {
-      const detected = await detectRenderMode();
-      renderMode = detected;
-      updateBadge();
-      crtEffects.setRenderMode(detected);
+    setupReduceMotion();
+    if (canvas) {
+      updateCanvasSize();
+    }
 
-      if (detected === 'css') {
-        canvasHidden = true;
-        logger.info('CRT postFX using CSS/SVG overlays');
+    const setup = async () => {
+      await detectCapabilities();
+      if (destroyed) {
         return;
       }
-
-      if (typeof window.matchMedia === 'function') {
-        reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-        reduceMotion = reduceMotionQuery.matches;
-      } else {
-        reduceMotionQuery = null;
-        reduceMotion = false;
-      }
-
-      logger.info('CRT postFX renderer initialized', { mode: detected });
-
-      await initializeRenderer();
-      updateEffectUniforms();
-
-      const throttle = reduceMotion ? 160 : 80;
-      domCapture = createDomCapture({
-        root: document.documentElement,
-        throttleMs: throttle,
-        ignore: (element) =>
-          element instanceof HTMLElement && element.dataset?.crtPostfxIgnore === 'true',
-        onCapture: async (frame) => {
-          if (!renderer) {
-            frame.bitmap.close();
-            return;
-          }
-          try {
-            await renderer.updateTexture(frame);
-            hasTexture = true;
-            updateRenderState();
-            if (shouldRender()) {
-              startLoop();
-            }
-          } catch (error) {
-            frame.bitmap.close();
-            logger.warn('CRT postFX texture upload failed', error);
-          }
-        }
-      });
-
-      if (reduceMotionQuery) {
-        domCapture.updateThrottle(reduceMotion ? 160 : 80);
-        updateEffectUniforms();
-        motionListener = (event) => {
-          reduceMotion = event.matches;
-          domCapture?.updateThrottle(reduceMotion ? 160 : 80);
-          updateEffectUniforms();
-          const wasRunning = running;
-          stopLoop();
-          if (wasRunning && shouldRender()) {
-            startLoop();
-          }
-        };
-        if ('addEventListener' in reduceMotionQuery) {
-          reduceMotionQuery.addEventListener('change', motionListener);
-        } else if ('addListener' in reduceMotionQuery) {
-          // @ts-expect-error Safari <16
-          reduceMotionQuery.addListener(motionListener);
-        }
-      } else {
-        updateEffectUniforms();
-      }
-
+      ensureMode();
       if (typeof document !== 'undefined') {
         document.addEventListener('visibilitychange', handleVisibility);
       }
       if (typeof window !== 'undefined') {
         window.addEventListener('resize', handleResize);
       }
-
-      updateRenderState();
-      if (typeof document !== 'undefined' && !document.hidden) {
-        domCapture.captureImmediate().catch((error) => {
-          logger.warn('CRT postFX initial capture failed', error);
-        });
-      }
     };
 
     setup().catch((error) => {
       logger.error('CRT postFX failed to initialize', error);
-      domCapture?.destroy();
-      domCapture = null;
-      renderer?.destroy();
-      renderer = null;
-      hasTexture = false;
       renderMode = 'css';
-      badgeLabel = BADGE_LABELS.css;
       canvasHidden = true;
       crtEffects.setRenderMode('css');
     });
 
     return () => {
-      effectsUnsubscribe();
+      unsubscribe();
     };
   });
 
   onDestroy(() => {
-    stopLoop();
-    domCapture?.destroy();
-    domCapture = null;
-    renderer?.destroy();
-    renderer = null;
+    destroyed = true;
+    teardownGpu();
+    lutController.dispose();
     if (reduceMotionQuery && motionListener) {
       if ('removeEventListener' in reduceMotionQuery) {
         reduceMotionQuery.removeEventListener('change', motionListener);
       } else if ('removeListener' in reduceMotionQuery) {
-        // @ts-expect-error Safari <16
+        // @ts-expect-error Legacy Safari
         reduceMotionQuery.removeListener(motionListener);
       }
     }
@@ -346,6 +720,7 @@
     bind:this={canvas}
     data-crt-postfx-ignore="true"
     data-hidden={canvasHidden}
+    data-interactive={interactive}
   ></canvas>
   <span class="crt-postfx__badge" data-mode={renderMode}>{badgeLabel}</span>
 </div>
@@ -367,12 +742,17 @@
     width: 100%;
     height: 100%;
     display: block;
-    pointer-events: none;
     background-color: black;
+    pointer-events: none;
   }
 
   .crt-postfx__canvas[data-hidden='true'] {
     opacity: 0;
+  }
+
+  .crt-postfx__canvas[data-interactive='true'] {
+    pointer-events: auto;
+    cursor: none;
   }
 
   .crt-postfx__badge {
@@ -399,4 +779,3 @@
     }
   }
 </style>
-

--- a/src/lib/crt/eventProxy.ts
+++ b/src/lib/crt/eventProxy.ts
@@ -1,0 +1,385 @@
+import { bilinearSample, type LutResult } from './geometryMath';
+
+interface LutSample {
+  width: number;
+  height: number;
+  data: Float32Array;
+}
+
+export interface CursorState {
+  screenX: number;
+  screenY: number;
+  domX: number;
+  domY: number;
+  pointerType: string;
+  buttons: number;
+  visible: boolean;
+}
+
+export interface PointerActivityState {
+  pointerDown: boolean;
+  pointerType: string;
+}
+
+export interface EventProxyOptions {
+  canvas: HTMLCanvasElement;
+  getLut: () => LutSample | null;
+  onCursor?: (state: CursorState) => void;
+  onActivity?: (state: PointerActivityState) => void;
+  logLatency?: (value: number) => void;
+}
+
+export interface EventProxyController {
+  updateLut(result: LutResult | null): void;
+  destroy(): void;
+}
+
+const focusElement = (target: EventTarget | null) => {
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const focusable =
+    target.tabIndex >= 0 ||
+    target instanceof HTMLButtonElement ||
+    target instanceof HTMLAnchorElement ||
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement;
+
+  if (focusable) {
+    target.focus({ preventScroll: true });
+  }
+};
+
+export const createEventProxy = ({
+  canvas,
+  getLut,
+  onCursor,
+  onActivity,
+  logLatency
+}: EventProxyOptions): EventProxyController => {
+  let disposed = false;
+  let lut: LutSample | null = null;
+
+  const pointerTargets = new Map<number, EventTarget>();
+  const pointerPositions = new Map<number, { x: number; y: number }>();
+  const pointerButtons = new Map<number, number>();
+
+  let pointerEventsDisabled = false;
+  let restoreHandle = 0;
+
+  const disableForHitTest = () => {
+    if (pointerEventsDisabled) {
+      return;
+    }
+    pointerEventsDisabled = true;
+    canvas.style.pointerEvents = 'none';
+    restoreHandle = window.requestAnimationFrame(() => {
+      canvas.style.pointerEvents = '';
+      pointerEventsDisabled = false;
+      restoreHandle = 0;
+    });
+  };
+
+  const cancelRestore = () => {
+    if (restoreHandle) {
+      window.cancelAnimationFrame(restoreHandle);
+      restoreHandle = 0;
+    }
+  };
+
+  const samplePoint = (x: number, y: number) => {
+    const sample = lut ?? getLut();
+    if (!sample) {
+      return { x, y };
+    }
+    return bilinearSample(sample.data, sample.width, sample.height, x, y);
+  };
+
+  const updateCursor = (payload: CursorState) => {
+    onCursor?.(payload);
+  };
+
+  const updateActivity = (state: PointerActivityState) => {
+    onActivity?.(state);
+  };
+
+  const getTarget = (pointerId: number, coordinates: { x: number; y: number }) => {
+    const captured = pointerTargets.get(pointerId);
+    if (captured) {
+      return captured;
+    }
+    disableForHitTest();
+    const target = document.elementFromPoint(coordinates.x, coordinates.y) ?? document.body;
+    return target;
+  };
+
+  const buildPointerInit = (
+    event: PointerEvent,
+    coords: { x: number; y: number },
+    movement: { x: number; y: number }
+  ): PointerEventInit => ({
+    bubbles: true,
+    cancelable: event.cancelable,
+    composed: event.composed,
+    pointerId: event.pointerId,
+    pointerType: event.pointerType,
+    isPrimary: event.isPrimary,
+    pressure: event.pressure,
+    tangentialPressure: event.tangentialPressure,
+    tiltX: event.tiltX,
+    tiltY: event.tiltY,
+    twist: event.twist,
+    width: event.width,
+    height: event.height,
+    clientX: coords.x,
+    clientY: coords.y,
+    pageX: coords.x + window.scrollX,
+    pageY: coords.y + window.scrollY,
+    screenX: event.screenX + (coords.x - event.clientX),
+    screenY: event.screenY + (coords.y - event.clientY),
+    movementX: movement.x,
+    movementY: movement.y,
+    button: event.button,
+    buttons: event.buttons,
+    ctrlKey: event.ctrlKey,
+    shiftKey: event.shiftKey,
+    altKey: event.altKey,
+    metaKey: event.metaKey
+  });
+
+  const dispatchPointer = (
+    type: string,
+    source: PointerEvent,
+    coords: { x: number; y: number },
+    preserveTarget = false
+  ) => {
+    const previous = pointerPositions.get(source.pointerId) ?? coords;
+    const movement = { x: coords.x - previous.x, y: coords.y - previous.y };
+    pointerPositions.set(source.pointerId, coords);
+
+    const target = preserveTarget
+      ? pointerTargets.get(source.pointerId) ?? getTarget(source.pointerId, coords)
+      : getTarget(source.pointerId, coords);
+
+    const init = buildPointerInit(source, coords, movement);
+    const synthetic = new PointerEvent(type, init);
+    const dispatched = target.dispatchEvent(synthetic);
+    if (!dispatched && source.cancelable) {
+      source.preventDefault();
+    }
+    return target;
+  };
+
+  const handlePointerDown = (event: PointerEvent) => {
+    const start = performance.now();
+    const coords = samplePoint(event.clientX, event.clientY);
+    const target = dispatchPointer('pointerdown', event, coords);
+    pointerTargets.set(event.pointerId, target);
+    pointerButtons.set(event.pointerId, event.buttons);
+    updateActivity({ pointerDown: true, pointerType: event.pointerType });
+    focusElement(target);
+    updateCursor({
+      screenX: event.clientX,
+      screenY: event.clientY,
+      domX: coords.x,
+      domY: coords.y,
+      pointerType: event.pointerType,
+      buttons: event.buttons,
+      visible: true
+    });
+    logLatency?.(performance.now() - start);
+  };
+
+  const handlePointerMove = (event: PointerEvent) => {
+    const process = (source: PointerEvent) => {
+      const start = performance.now();
+      const coords = samplePoint(source.clientX, source.clientY);
+      const target = dispatchPointer('pointermove', source, coords, true);
+      pointerButtons.set(source.pointerId, source.buttons);
+      updateCursor({
+        screenX: source.clientX,
+        screenY: source.clientY,
+        domX: coords.x,
+        domY: coords.y,
+        pointerType: source.pointerType,
+        buttons: source.buttons,
+        visible: true
+      });
+      focusElement(source.buttons > 0 ? target : null);
+      logLatency?.(performance.now() - start);
+    };
+
+    const coalesced = event.getCoalescedEvents?.();
+    if (coalesced && coalesced.length > 0) {
+      coalesced.forEach((coalescedEvent) => {
+        process(coalescedEvent as PointerEvent);
+      });
+    } else {
+      process(event);
+    }
+  };
+
+  const finishPointer = (event: PointerEvent, type: 'pointerup' | 'pointercancel') => {
+    const start = performance.now();
+    const coords = samplePoint(event.clientX, event.clientY);
+    dispatchPointer(type, event, coords, true);
+    pointerTargets.delete(event.pointerId);
+    pointerPositions.delete(event.pointerId);
+    pointerButtons.delete(event.pointerId);
+    updateActivity({ pointerDown: false, pointerType: event.pointerType });
+    updateCursor({
+      screenX: event.clientX,
+      screenY: event.clientY,
+      domX: coords.x,
+      domY: coords.y,
+      pointerType: event.pointerType,
+      buttons: 0,
+      visible: type === 'pointerup'
+    });
+    logLatency?.(performance.now() - start);
+  };
+
+  const handlePointerUp = (event: PointerEvent) => {
+    finishPointer(event, 'pointerup');
+  };
+
+  const handlePointerCancel = (event: PointerEvent) => {
+    finishPointer(event, 'pointercancel');
+  };
+
+  const handlePointerEnter = (event: PointerEvent) => {
+    const coords = samplePoint(event.clientX, event.clientY);
+    updateCursor({
+      screenX: event.clientX,
+      screenY: event.clientY,
+      domX: coords.x,
+      domY: coords.y,
+      pointerType: event.pointerType,
+      buttons: event.buttons,
+      visible: true
+    });
+  };
+
+  const handlePointerLeave = (event: PointerEvent) => {
+    pointerTargets.delete(event.pointerId);
+    pointerPositions.delete(event.pointerId);
+    pointerButtons.delete(event.pointerId);
+    updateCursor({
+      screenX: event.clientX,
+      screenY: event.clientY,
+      domX: event.clientX,
+      domY: event.clientY,
+      pointerType: event.pointerType,
+      buttons: 0,
+      visible: false
+    });
+  };
+
+  const handleWheel = (event: WheelEvent) => {
+    const start = performance.now();
+    const coords = samplePoint(event.clientX, event.clientY);
+    const target = getTarget(-1, coords);
+    const synthetic = new WheelEvent(event.type, {
+      bubbles: true,
+      cancelable: event.cancelable,
+      composed: event.composed,
+      deltaMode: event.deltaMode,
+      deltaX: event.deltaX,
+      deltaY: event.deltaY,
+      deltaZ: event.deltaZ,
+      clientX: coords.x,
+      clientY: coords.y,
+      screenX: event.screenX + (coords.x - event.clientX),
+      screenY: event.screenY + (coords.y - event.clientY),
+      ctrlKey: event.ctrlKey,
+      shiftKey: event.shiftKey,
+      altKey: event.altKey,
+      metaKey: event.metaKey
+    });
+    const dispatched = target.dispatchEvent(synthetic);
+    if (!dispatched && event.cancelable) {
+      event.preventDefault();
+    }
+    logLatency?.(performance.now() - start);
+  };
+
+  const handleMouseLike = (event: MouseEvent) => {
+    const start = performance.now();
+    const coords = samplePoint(event.clientX, event.clientY);
+    const target = getTarget(-1, coords);
+    const synthetic = new MouseEvent(event.type, {
+      bubbles: true,
+      cancelable: event.cancelable,
+      composed: event.composed,
+      clientX: coords.x,
+      clientY: coords.y,
+      screenX: event.screenX + (coords.x - event.clientX),
+      screenY: event.screenY + (coords.y - event.clientY),
+      button: event.button,
+      buttons: event.buttons,
+      ctrlKey: event.ctrlKey,
+      shiftKey: event.shiftKey,
+      altKey: event.altKey,
+      metaKey: event.metaKey
+    });
+    const dispatched = target.dispatchEvent(synthetic);
+    if (!dispatched && event.cancelable) {
+      event.preventDefault();
+    }
+    if (event.type === 'dblclick' || event.type === 'click') {
+      focusElement(target);
+    }
+    logLatency?.(performance.now() - start);
+  };
+
+  const handleContextMenu = (event: MouseEvent) => {
+    handleMouseLike(event);
+  };
+
+  canvas.addEventListener('pointerdown', handlePointerDown);
+  canvas.addEventListener('pointermove', handlePointerMove);
+  canvas.addEventListener('pointerup', handlePointerUp);
+  canvas.addEventListener('pointercancel', handlePointerCancel);
+  canvas.addEventListener('pointerenter', handlePointerEnter);
+  canvas.addEventListener('pointerleave', handlePointerLeave);
+  canvas.addEventListener('wheel', handleWheel, { passive: false });
+  canvas.addEventListener('click', handleMouseLike, true);
+  canvas.addEventListener('dblclick', handleMouseLike, true);
+  canvas.addEventListener('contextmenu', handleContextMenu, true);
+
+  const destroy = () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    cancelRestore();
+    canvas.removeEventListener('pointerdown', handlePointerDown);
+    canvas.removeEventListener('pointermove', handlePointerMove);
+    canvas.removeEventListener('pointerup', handlePointerUp);
+    canvas.removeEventListener('pointercancel', handlePointerCancel);
+    canvas.removeEventListener('pointerenter', handlePointerEnter);
+    canvas.removeEventListener('pointerleave', handlePointerLeave);
+    canvas.removeEventListener('wheel', handleWheel);
+    canvas.removeEventListener('click', handleMouseLike, true);
+    canvas.removeEventListener('dblclick', handleMouseLike, true);
+    canvas.removeEventListener('contextmenu', handleContextMenu, true);
+    pointerTargets.clear();
+    pointerPositions.clear();
+    pointerButtons.clear();
+  };
+
+  const updateLut = (result: LutResult | null) => {
+    if (!result) {
+      lut = null;
+      return;
+    }
+    lut = {
+      width: result.width,
+      height: result.height,
+      data: result.inverse
+    } satisfies LutSample;
+  };
+
+  return { updateLut, destroy };
+};

--- a/src/lib/crt/float16.ts
+++ b/src/lib/crt/float16.ts
@@ -1,0 +1,76 @@
+const baseBuffer = new ArrayBuffer(4);
+const floatView = new Float32Array(baseBuffer);
+const intView = new Uint32Array(baseBuffer);
+
+export const float32ToFloat16 = (value: number) => {
+  floatView[0] = value;
+  const x = intView[0];
+
+  const sign = (x >> 16) & 0x8000;
+  const exponent = ((x >> 23) & 0xff) - 112;
+  let mantissa = x & 0x7fffff;
+
+  if (exponent <= 0) {
+    if (exponent < -10) {
+      return sign;
+    }
+    mantissa = (mantissa | 0x800000) >> (1 - exponent);
+    return sign | ((mantissa + 0x1000) >> 13);
+  }
+
+  if (exponent === 143 - 112) {
+    if (mantissa === 0) {
+      return sign | 0x7c00;
+    }
+    mantissa >>= 13;
+    return sign | 0x7c00 | mantissa | (mantissa === 0 ? 1 : 0);
+  }
+
+  if (exponent > 30) {
+    return sign | 0x7c00;
+  }
+
+  return sign | (exponent << 10) | ((mantissa + 0x1000) >> 13);
+};
+
+export const float16ToFloat32 = (value: number) => {
+  const sign = (value & 0x8000) << 16;
+  let exponent = value & 0x7c00;
+  let mantissa = value & 0x03ff;
+
+  if (exponent === 0x7c00) {
+    exponent = 0xff << 23;
+    if (mantissa) {
+      mantissa = mantissa << 13;
+    }
+  } else if (exponent !== 0) {
+    exponent = (exponent + 0x1c000) << 13;
+    mantissa <<= 13;
+  } else if (mantissa !== 0) {
+    exponent = 0x1c400000;
+    while ((mantissa & 0x0400) === 0) {
+      mantissa <<= 1;
+      exponent -= 0x00800000;
+    }
+    mantissa = (mantissa & 0x03ff) << 13;
+  }
+
+  intView[0] = sign | exponent | mantissa;
+  return floatView[0];
+};
+
+export const encodeFloat32To16 = (source: Float32Array) => {
+  const result = new Uint16Array(source.length);
+  for (let i = 0; i < source.length; i += 1) {
+    result[i] = float32ToFloat16(source[i]);
+  }
+  return result;
+};
+
+export const decodeFloat16To32 = (source: Uint16Array) => {
+  const result = new Float32Array(source.length);
+  for (let i = 0; i < source.length; i += 1) {
+    result[i] = float16ToFloat32(source[i]);
+  }
+  return result;
+};

--- a/src/lib/crt/geometryMath.ts
+++ b/src/lib/crt/geometryMath.ts
@@ -1,0 +1,166 @@
+export interface GeometryParams {
+  width: number; // CSS pixels
+  height: number; // CSS pixels
+  dpr: number;
+  k1: number;
+  k2: number;
+}
+
+export interface LutResult {
+  forward: Float32Array;
+  inverse: Float32Array;
+  width: number;
+  height: number;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const solveRadius = (distorted: number, k1: number, k2: number) => {
+  if (distorted === 0) {
+    return 0;
+  }
+
+  let radius = distorted;
+  for (let i = 0; i < 8; i += 1) {
+    const r2 = radius * radius;
+    const r4 = r2 * r2;
+    const factor = 1 + k1 * r2 + k2 * r4;
+    const value = radius * factor - distorted;
+    const derivative = factor + radius * (2 * k1 * radius + 4 * k2 * r2 * radius);
+    if (Math.abs(derivative) < 1e-6) {
+      break;
+    }
+    radius -= value / derivative;
+  }
+  return radius;
+};
+
+const normalize = (coord: number, size: number) => (coord / size) * 2 - 1;
+
+const denormalize = (value: number, size: number) => ((value + 1) * 0.5) * size;
+
+const mapDomToScreen = (x: number, y: number, params: GeometryParams) => {
+  const { width, height, k1, k2 } = params;
+  const aspect = width / height;
+
+  const normX = normalize(x, width);
+  const normY = normalize(y, height);
+  let px = normX * aspect;
+  let py = normY;
+  const r2 = px * px + py * py;
+  const r4 = r2 * r2;
+  const factor = 1 + k1 * r2 + k2 * r4;
+  px *= factor;
+  py *= factor;
+
+  const distortedX = px / aspect;
+  const distortedY = py;
+
+  return {
+    x: clamp(denormalize(distortedX, width), 0, width),
+    y: clamp(denormalize(distortedY, height), 0, height)
+  };
+};
+
+const mapScreenToDom = (x: number, y: number, params: GeometryParams) => {
+  const { width, height, k1, k2 } = params;
+  const aspect = width / height;
+
+  const normX = normalize(x, width);
+  const normY = normalize(y, height);
+  let px = normX * aspect;
+  let py = normY;
+  const radiusPrime = Math.sqrt(px * px + py * py);
+
+  if (radiusPrime === 0) {
+    return { x: width * 0.5, y: height * 0.5 };
+  }
+
+  const radius = solveRadius(radiusPrime, k1, k2);
+  const scale = radius / radiusPrime;
+  px *= scale;
+  py *= scale;
+
+  const undistortedX = px / aspect;
+  const undistortedY = py;
+
+  return {
+    x: clamp(denormalize(undistortedX, width), 0, width),
+    y: clamp(denormalize(undistortedY, height), 0, height)
+  };
+};
+
+export const generateLuts = (params: GeometryParams): LutResult => {
+  const width = Math.max(1, Math.round(params.width));
+  const height = Math.max(1, Math.round(params.height));
+  const forward = new Float32Array(width * height * 2);
+  const inverse = new Float32Array(width * height * 2);
+
+  let index = 0;
+  for (let y = 0; y < height; y += 1) {
+    const sampleY = y + 0.5;
+    for (let x = 0; x < width; x += 1) {
+      const sampleX = x + 0.5;
+      const forwardPoint = mapDomToScreen(sampleX, sampleY, params);
+      const inversePoint = mapScreenToDom(sampleX, sampleY, params);
+
+      forward[index] = forwardPoint.x;
+      forward[index + 1] = forwardPoint.y;
+      inverse[index] = inversePoint.x;
+      inverse[index + 1] = inversePoint.y;
+      index += 2;
+    }
+  }
+
+  return { forward, inverse, width, height };
+};
+
+export const bilinearSample = (
+  data: Float32Array,
+  width: number,
+  height: number,
+  x: number,
+  y: number
+) => {
+  if (width <= 0 || height <= 0) {
+    return { x, y };
+  }
+
+  const clampedX = clamp(x, 0, width - 1);
+  const clampedY = clamp(y, 0, height - 1);
+  const x0 = Math.floor(clampedX);
+  const x1 = Math.min(width - 1, x0 + 1);
+  const y0 = Math.floor(clampedY);
+  const y1 = Math.min(height - 1, y0 + 1);
+  const tx = clampedX - x0;
+  const ty = clampedY - y0;
+
+  const sample = (sx: number, sy: number) => {
+    const idx = (sy * width + sx) * 2;
+    return { x: data[idx], y: data[idx + 1] };
+  };
+
+  const s00 = sample(x0, y0);
+  const s10 = sample(x1, y0);
+  const s01 = sample(x0, y1);
+  const s11 = sample(x1, y1);
+
+  const ix0 = {
+    x: s00.x + (s10.x - s00.x) * tx,
+    y: s00.y + (s10.y - s00.y) * tx
+  };
+  const ix1 = {
+    x: s01.x + (s11.x - s01.x) * tx,
+    y: s01.y + (s11.y - s01.y) * tx
+  };
+
+  return {
+    x: ix0.x + (ix1.x - ix0.x) * ty,
+    y: ix0.y + (ix1.y - ix0.y) * ty
+  };
+};
+
+export const geometryDefaults = {
+  forward: mapDomToScreen,
+  inverse: mapScreenToDom
+};

--- a/src/lib/crt/lutController.ts
+++ b/src/lib/crt/lutController.ts
@@ -1,0 +1,74 @@
+import type { GeometryParams, LutResult } from './geometryMath';
+
+interface PendingRequest {
+  resolve: (value: LutResult) => void;
+  reject: (error: Error) => void;
+}
+
+export interface LutController {
+  request(params: GeometryParams): Promise<LutResult>;
+  dispose(): void;
+}
+
+export const createLutController = (): LutController => {
+  let worker: Worker | null = null;
+  let requestId = 0;
+  const pending = new Map<number, PendingRequest>();
+
+  const ensureWorker = () => {
+    if (worker) {
+      return;
+    }
+    worker = new Worker(new URL('./lutWorker.ts', import.meta.url), { type: 'module' });
+    worker.addEventListener('message', (event: MessageEvent<{ id: number; error?: string } & LutResult>) => {
+      const { id, error, ...rest } = event.data;
+      const handle = pending.get(id);
+      if (!handle) {
+        return;
+      }
+      pending.delete(id);
+      if (error) {
+        handle.reject(new Error(error));
+        return;
+      }
+      if (!rest.forward || !rest.inverse || !rest.width || !rest.height) {
+        handle.reject(new Error('Malformed LUT payload'));
+        return;
+      }
+      handle.resolve({
+        forward: rest.forward,
+        inverse: rest.inverse,
+        width: rest.width,
+        height: rest.height
+      });
+    });
+    worker.addEventListener('error', (error) => {
+      pending.forEach((entry) => entry.reject(error instanceof Error ? error : new Error('LUT worker error')));
+      pending.clear();
+    });
+  };
+
+  const request = (params: GeometryParams) => {
+    ensureWorker();
+    if (!worker) {
+      return Promise.reject(new Error('LUT worker unavailable'));
+    }
+
+    const id = ++requestId;
+    return new Promise<LutResult>((resolve, reject) => {
+      pending.set(id, { resolve, reject });
+      worker?.postMessage({ id, params });
+    });
+  };
+
+  const dispose = () => {
+    if (worker) {
+      worker.terminate();
+      worker = null;
+    }
+    pending.forEach((entry) => entry.reject(new Error('LUT controller disposed')));
+    pending.clear();
+  };
+
+  return { request, dispose };
+};

--- a/src/lib/crt/lutWorker.ts
+++ b/src/lib/crt/lutWorker.ts
@@ -1,0 +1,40 @@
+import { generateLuts, type GeometryParams } from './geometryMath';
+
+interface WorkerRequest {
+  id: number;
+  params: GeometryParams;
+}
+
+interface WorkerResponse {
+  id: number;
+  error?: string;
+  forward?: Float32Array;
+  inverse?: Float32Array;
+  width?: number;
+  height?: number;
+}
+
+const ctx: DedicatedWorkerGlobalScope = self as DedicatedWorkerGlobalScope;
+
+const respond = (message: WorkerResponse) => {
+  const transfers: ArrayBuffer[] = [];
+  if (message.forward) {
+    transfers.push(message.forward.buffer);
+  }
+  if (message.inverse) {
+    transfers.push(message.inverse.buffer);
+  }
+  ctx.postMessage(message, transfers);
+};
+
+ctx.onmessage = (event: MessageEvent<WorkerRequest>) => {
+  const { id, params } = event.data;
+
+  try {
+    const { forward, inverse, width, height } = generateLuts(params);
+    respond({ id, forward, inverse, width, height });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown LUT error';
+    respond({ id, error: message });
+  }
+};

--- a/src/lib/crt/shaders/crt.frag.glsl
+++ b/src/lib/crt/shaders/crt.frag.glsl
@@ -2,18 +2,14 @@
 precision highp float;
 
 uniform sampler2D uScene;
-uniform vec2 uResolution;
-uniform vec2 uInvResolution;
-uniform float uTime;
-uniform float uScanlineIntensity;
-uniform float uSlotMaskIntensity;
-uniform float uVignetteStrength;
-uniform float uBloomIntensity;
-uniform float uAberrationStrength;
-uniform float uNoiseIntensity;
-uniform float uDevicePixelRatio;
-uniform float uBloomThreshold;
-uniform float uBloomSoftness;
+uniform sampler2D uForwardLut;
+uniform vec4 uResolution; // width, height, invWidth, invHeight
+uniform vec4 uTiming; // time, scanline, slotMask, vignette
+uniform vec4 uEffects; // bloom, aberration, noise, dpr
+uniform vec4 uBloomParams; // threshold, softness, k1, k2
+uniform vec4 uCssMetrics; // cssWidth, cssHeight, invCssWidth, invCssHeight
+uniform vec4 uCursorState; // x, y, visible, buttons
+uniform vec4 uCursorMeta; // type, bloomAttenuation, reserved
 
 in vec2 vUv;
 out vec4 fragColor;
@@ -22,27 +18,78 @@ vec2 clampUv(vec2 value) {
   return clamp(value, vec2(0.0), vec2(1.0));
 }
 
-void main() {
-  vec2 uv = vUv;
-  vec3 color = texture(uScene, clampUv(uv)).rgb;
+vec2 clampCss(vec2 value, vec2 size) {
+  return vec2(clamp(value.x, 0.0, size.x), clamp(value.y, 0.0, size.y));
+}
 
-  if (uAberrationStrength > 0.0001) {
-    vec2 center = uv - vec2(0.5);
-    vec2 offset = center * uAberrationStrength * 1.35;
-    float redSample = texture(uScene, clampUv(uv + offset)).r;
-    float blueSample = texture(uScene, clampUv(uv - offset)).b;
-    color.r = mix(color.r, redSample, min(0.85, uAberrationStrength * 0.85));
-    color.b = mix(color.b, blueSample, min(0.85, uAberrationStrength * 0.85));
+vec2 cssToSceneUv(vec2 css, float dpr, vec2 invResolution) {
+  return vec2(css.x * dpr * invResolution.x, css.y * dpr * invResolution.y);
+}
+
+float vignetteMask(vec2 css, vec2 invCss) {
+  vec2 normalized = css * invCss - vec2(0.5);
+  float distance = length(normalized);
+  return smoothstep(0.85, 0.55, distance);
+}
+
+float cursorRadius(float cursorType) {
+  if (cursorType > 1.5) {
+    return 16.0;
+  }
+  if (cursorType > 0.5) {
+    return 22.0;
+  }
+  return 12.0;
+}
+
+void main() {
+  vec2 uv = clampUv(vUv);
+  vec2 resolution = uResolution.xy;
+  vec2 invResolution = uResolution.zw;
+  float time = uTiming.x;
+  float scanlineIntensity = uTiming.y;
+  float slotMaskIntensity = uTiming.z;
+  float vignetteStrength = uTiming.w;
+  float baseBloomIntensity = uEffects.x;
+  float aberrationStrength = uEffects.y;
+  float noiseIntensity = uEffects.z;
+  float devicePixelRatio = uEffects.w;
+  float bloomThreshold = uBloomParams.x;
+  float bloomSoftness = uBloomParams.y;
+  vec2 cssSize = uCssMetrics.xy;
+  vec2 invCss = uCssMetrics.zw;
+  vec4 cursor = uCursorState;
+  vec4 cursorMeta = uCursorMeta;
+
+  float bloomIntensity = baseBloomIntensity * cursorMeta.y;
+
+  vec2 cssCoord = clampCss(texture(uForwardLut, uv).xy, cssSize);
+  vec2 sceneUv = clampUv(cssToSceneUv(cssCoord, devicePixelRatio, invResolution));
+  vec3 color = texture(uScene, sceneUv).rgb;
+
+  if (aberrationStrength > 0.0001) {
+    vec2 center = cssCoord - cssSize * 0.5;
+    float magnitude = max(length(center), 0.001);
+    vec2 direction = center / magnitude;
+    float offsetAmount = aberrationStrength * 6.0;
+    vec2 redCss = clampCss(cssCoord + direction * offsetAmount, cssSize);
+    vec2 blueCss = clampCss(cssCoord - direction * offsetAmount, cssSize);
+    vec2 redUv = clampUv(cssToSceneUv(redCss, devicePixelRatio, invResolution));
+    vec2 blueUv = clampUv(cssToSceneUv(blueCss, devicePixelRatio, invResolution));
+    float redSample = texture(uScene, redUv).r;
+    float blueSample = texture(uScene, blueUv).b;
+    color.r = mix(color.r, redSample, min(0.85, aberrationStrength * 0.85));
+    color.b = mix(color.b, blueSample, min(0.85, aberrationStrength * 0.85));
   }
 
-  if (uScanlineIntensity > 0.0001) {
-    float line = sin((uv.y * uResolution.y) / uDevicePixelRatio * 3.14159265);
-    float mask = mix(1.0, 0.55 + 0.45 * line * line, uScanlineIntensity);
+  if (scanlineIntensity > 0.0001) {
+    float line = sin(cssCoord.y * devicePixelRatio * 3.14159265);
+    float mask = mix(1.0, 0.55 + 0.45 * line * line, scanlineIntensity);
     color *= mask;
   }
 
-  if (uSlotMaskIntensity > 0.0001) {
-    int triad = int(floor((uv.x * uResolution.x) / uDevicePixelRatio)) % 3;
+  if (slotMaskIntensity > 0.0001) {
+    int triad = int(floor(cssCoord.x * devicePixelRatio)) % 3;
     vec3 slotMask = vec3(0.35);
     if (triad == 0) {
       slotMask.r = 1.0;
@@ -51,41 +98,51 @@ void main() {
     } else {
       slotMask.b = 1.0;
     }
-    color *= mix(vec3(1.0), slotMask, uSlotMaskIntensity);
+    color *= mix(vec3(1.0), slotMask, slotMaskIntensity);
   }
 
-  if (uBloomIntensity > 0.0001) {
+  if (bloomIntensity > 0.0001) {
     vec3 accum = vec3(0.0);
     vec2 taps[5];
     taps[0] = vec2(0.0);
-    taps[1] = vec2(uInvResolution.x * 2.0, 0.0);
-    taps[2] = vec2(-uInvResolution.x * 2.0, 0.0);
-    taps[3] = vec2(0.0, uInvResolution.y * 2.0);
-    taps[4] = vec2(0.0, -uInvResolution.y * 2.0);
-
+    taps[1] = vec2(invResolution.x * 2.0, 0.0);
+    taps[2] = vec2(-invResolution.x * 2.0, 0.0);
+    taps[3] = vec2(0.0, invResolution.y * 2.0);
+    taps[4] = vec2(0.0, -invResolution.y * 2.0);
     for (int i = 0; i < 5; i++) {
-      vec2 sampleUv = clampUv(uv + taps[i]);
+      vec2 sampleUv = clampUv(sceneUv + taps[i]);
       accum += texture(uScene, sampleUv).rgb;
     }
     accum /= 5.0;
     float luminance = dot(accum, vec3(0.2126, 0.7152, 0.0722));
-    float weight = smoothstep(uBloomThreshold, 1.0, luminance);
-    color = mix(color, accum, weight * uBloomIntensity * uBloomSoftness);
+    float weight = smoothstep(bloomThreshold, 1.0, luminance);
+    color = mix(color, accum, weight * bloomIntensity * bloomSoftness);
   }
 
-  if (uVignetteStrength > 0.0001) {
-    float dist = distance(uv, vec2(0.5));
-    float vig = smoothstep(0.75, 0.45, dist);
-    color *= mix(1.0, vig, uVignetteStrength);
+  if (vignetteStrength > 0.0001) {
+    float vig = vignetteMask(cssCoord, invCss);
+    color *= mix(1.0, vig, vignetteStrength);
   }
 
-  if (uNoiseIntensity > 0.0001) {
-    float noise = fract(sin(dot(uv * uResolution, vec2(12.9898, 78.233)) + uTime * 12.345) * 43758.5453);
-    float grain = (noise - 0.5) * uNoiseIntensity;
+  if (noiseIntensity > 0.0001) {
+    float noise = fract(sin(dot(cssCoord, vec2(12.9898, 78.233)) + time * 12.345) * 43758.5453);
+    float grain = (noise - 0.5) * noiseIntensity;
     color += vec3(grain);
+  }
+
+  if (cursor.z > 0.5) {
+    vec2 cursorUv = clampUv(cssToSceneUv(cursor.xy, devicePixelRatio, invResolution));
+    vec2 diff = vec2((uv.x - cursorUv.x) * resolution.x, (uv.y - cursorUv.y) * resolution.y);
+    float radius = cursorRadius(cursorMeta.x) * devicePixelRatio;
+    float dist = length(diff);
+    float ring = smoothstep(radius + 1.5, radius - 1.5, dist);
+    float fill = smoothstep(radius * 0.4, radius * 0.1, dist);
+    float alpha = max(ring, fill * 0.4);
+    float pressed = step(0.5, cursor.w);
+    vec3 tint = mix(vec3(1.0), vec3(0.85, 1.0, 0.85), pressed);
+    color = mix(color, tint, alpha);
   }
 
   color = clamp(color, 0.0, 1.0);
   fragColor = vec4(color, 1.0);
 }
-

--- a/src/lib/crt/shaders/crt.wgsl
+++ b/src/lib/crt/shaders/crt.wgsl
@@ -1,17 +1,21 @@
 struct Uniforms {
-  resolution: vec4<f32>,
-  factorsA: vec4<f32>,
-  factorsB: vec4<f32>,
-  factorsC: vec4<f32>,
+  resolution: vec4<f32>;
+  timing: vec4<f32>;
+  effects: vec4<f32>;
+  bloomParams: vec4<f32>;
+  cssMetrics: vec4<f32>;
+  cursorState: vec4<f32>;
+  cursorMeta: vec4<f32>;
 };
 
 @group(0) @binding(0) var linearSampler: sampler;
 @group(0) @binding(1) var sceneTexture: texture_2d<f32>;
 @group(0) @binding(2) var<uniform> uniforms: Uniforms;
+@group(0) @binding(3) var forwardLut: texture_2d<f32>;
 
 struct VertexOutput {
-  @builtin(position) position: vec4<f32>,
-  @location(0) uv: vec2<f32>,
+  @builtin(position) position: vec4<f32>;
+  @location(0) uv: vec2<f32>;
 };
 
 @vertex
@@ -38,29 +42,69 @@ fn clampUv(value: vec2<f32>) -> vec2<f32> {
   return clamp(value, vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 1.0));
 }
 
+fn clampCss(value: vec2<f32>, size: vec2<f32>) -> vec2<f32> {
+  return vec2<f32>(
+    clamp(value.x, 0.0, size.x),
+    clamp(value.y, 0.0, size.y)
+  );
+}
+
+fn cssToSceneUv(css: vec2<f32>, dpr: f32, invResolution: vec2<f32>) -> vec2<f32> {
+  return vec2<f32>(css.x * dpr * invResolution.x, css.y * dpr * invResolution.y);
+}
+
+fn vignetteMask(css: vec2<f32>, invCss: vec2<f32>) -> f32 {
+  let normalized = css * invCss - vec2<f32>(0.5, 0.5);
+  let distance = length(normalized);
+  return smoothstep(0.85, 0.55, distance);
+}
+
+fn cursorRadius(cursorType: f32) -> f32 {
+  if (cursorType > 1.5) {
+    return 16.0;
+  }
+  if (cursorType > 0.5) {
+    return 22.0;
+  }
+  return 12.0;
+}
+
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-  let uv = input.uv;
+  let uv = clampUv(input.uv);
   let resolution = uniforms.resolution.xy;
   let invResolution = uniforms.resolution.zw;
-  let time = uniforms.factorsA.x;
-  let scanlineIntensity = uniforms.factorsA.y;
-  let slotMaskIntensity = uniforms.factorsA.z;
-  let vignetteStrength = uniforms.factorsA.w;
-  let bloomIntensity = uniforms.factorsB.x;
-  let aberrationStrength = uniforms.factorsB.y;
-  let noiseIntensity = uniforms.factorsB.z;
-  let devicePixelRatio = uniforms.factorsB.w;
-  let bloomThreshold = uniforms.factorsC.x;
-  let bloomSoftness = uniforms.factorsC.y;
+  let time = uniforms.timing.x;
+  let scanlineIntensity = uniforms.timing.y;
+  let slotMaskIntensity = uniforms.timing.z;
+  let vignetteStrength = uniforms.timing.w;
+  let baseBloomIntensity = uniforms.effects.x;
+  let aberrationStrength = uniforms.effects.y;
+  let noiseIntensity = uniforms.effects.z;
+  let devicePixelRatio = uniforms.effects.w;
+  let bloomThreshold = uniforms.bloomParams.x;
+  let bloomSoftness = uniforms.bloomParams.y;
+  let cssSize = uniforms.cssMetrics.xy;
+  let invCss = uniforms.cssMetrics.zw;
+  let cursor = uniforms.cursorState;
+  let cursorMeta = uniforms.cursorMeta;
 
-  var color = textureSampleLevel(sceneTexture, linearSampler, clampUv(uv), 0.0).rgb;
+  let bloomIntensity = baseBloomIntensity * cursorMeta.y;
+
+  let cssCoordRaw = textureSampleLevel(forwardLut, linearSampler, uv, 0.0).xy;
+  let cssCoord = clampCss(cssCoordRaw, cssSize);
+  let sceneUv = clampUv(cssToSceneUv(cssCoord, devicePixelRatio, invResolution));
+  var color = textureSampleLevel(sceneTexture, linearSampler, sceneUv, 0.0).rgb;
 
   if (aberrationStrength > 0.0001) {
-    let center = uv - vec2<f32>(0.5, 0.5);
-    let offset = center * aberrationStrength * 1.35;
-    let redUv = clampUv(uv + offset);
-    let blueUv = clampUv(uv - offset);
+    let center = cssCoord - cssSize * 0.5;
+    let magnitude = max(length(center), 1e-3);
+    let direction = center / magnitude;
+    let offsetAmount = aberrationStrength * 6.0;
+    let redCss = clampCss(cssCoord + direction * offsetAmount, cssSize);
+    let blueCss = clampCss(cssCoord - direction * offsetAmount, cssSize);
+    let redUv = clampUv(cssToSceneUv(redCss, devicePixelRatio, invResolution));
+    let blueUv = clampUv(cssToSceneUv(blueCss, devicePixelRatio, invResolution));
     let redSample = textureSampleLevel(sceneTexture, linearSampler, redUv, 0.0).r;
     let blueSample = textureSampleLevel(sceneTexture, linearSampler, blueUv, 0.0).b;
     color.r = mix(color.r, redSample, min(0.85, aberrationStrength * 0.85));
@@ -68,13 +112,13 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
   }
 
   if (scanlineIntensity > 0.0001) {
-    let line = sin((uv.y * resolution.y) / devicePixelRatio * 3.14159265);
+    let line = sin(cssCoord.y * devicePixelRatio * 3.14159265);
     let mask = mix(1.0, 0.55 + 0.45 * line * line, scanlineIntensity);
     color = color * mask;
   }
 
   if (slotMaskIntensity > 0.0001) {
-    let triad = i32(floor((uv.x * resolution.x) / devicePixelRatio)) % 3;
+    let triad = i32(floor(cssCoord.x * devicePixelRatio)) % 3;
     var slotMask = vec3<f32>(0.35, 0.35, 0.35);
     if (triad == 0) {
       slotMask.x = 1.0;
@@ -88,7 +132,6 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
 
   if (bloomIntensity > 0.0001) {
     var accum = vec3<f32>(0.0, 0.0, 0.0);
-    let tapCount: u32 = 5u;
     let taps = array<vec2<f32>, 5>(
       vec2<f32>(0.0, 0.0),
       vec2<f32>(invResolution.x * 2.0, 0.0),
@@ -96,29 +139,40 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
       vec2<f32>(0.0, invResolution.y * 2.0),
       vec2<f32>(0.0, -invResolution.y * 2.0)
     );
-    for (var i = 0u; i < tapCount; i = i + 1u) {
-      let sampleUv = clampUv(uv + taps[i]);
+    for (var i = 0u; i < 5u; i = i + 1u) {
+      let sampleUv = clampUv(sceneUv + taps[i]);
       accum = accum + textureSampleLevel(sceneTexture, linearSampler, sampleUv, 0.0).rgb;
     }
-    accum = accum / f32(tapCount);
+    accum = accum / 5.0;
     let luminance = dot(accum, vec3<f32>(0.2126, 0.7152, 0.0722));
     let weight = smoothstep(bloomThreshold, 1.0, luminance);
     color = mix(color, accum, weight * bloomIntensity * bloomSoftness);
   }
 
   if (vignetteStrength > 0.0001) {
-    let dist = distance(uv, vec2<f32>(0.5, 0.5));
-    let vig = smoothstep(0.75, 0.45, dist);
+    let vig = vignetteMask(cssCoord, invCss);
     color = color * mix(1.0, vig, vignetteStrength);
   }
 
   if (noiseIntensity > 0.0001) {
-    let noise = fract(sin(dot(uv * resolution.xy, vec2<f32>(12.9898, 78.233)) + time * 12.345) * 43758.5453);
+    let noise = fract(sin(dot(cssCoord, vec2<f32>(12.9898, 78.233)) + time * 12.345) * 43758.5453);
     let grain = (noise - 0.5) * noiseIntensity;
     color = color + vec3<f32>(grain, grain, grain);
+  }
+
+  if (cursor.z > 0.5) {
+    let cursorUv = clampUv(cssToSceneUv(cursor.xy, devicePixelRatio, invResolution));
+    let diff = vec2<f32>((uv.x - cursorUv.x) * resolution.x, (uv.y - cursorUv.y) * resolution.y);
+    let radius = cursorRadius(cursorMeta.x) * devicePixelRatio;
+    let dist = length(diff);
+    let ring = smoothstep(radius + 1.5, radius - 1.5, dist);
+    let fill = smoothstep(radius * 0.4, radius * 0.1, dist);
+    let alpha = max(ring, fill * 0.4);
+    let pressed = step(0.5, cursor.w);
+    let tint = mix(vec3<f32>(1.0, 1.0, 1.0), vec3<f32>(0.85, 1.0, 0.85), pressed);
+    color = mix(color, tint, alpha);
   }
 
   color = clamp(color, vec3<f32>(0.0, 0.0, 0.0), vec3<f32>(1.0, 1.0, 1.0));
   return vec4<f32>(color, 1.0);
 }
-

--- a/src/lib/crt/shaders/crtLut.wgsl
+++ b/src/lib/crt/shaders/crtLut.wgsl
@@ -1,0 +1,86 @@
+struct LutUniforms {
+  size: vec4<f32>; // x=width, y=height, z=invWidth, w=invHeight
+  factors: vec4<f32>; // x=aspect, y=k1, z=k2, w=unused
+};
+
+@group(0) @binding(0) var<uniform> params: LutUniforms;
+@group(0) @binding(1) var forwardLut: texture_storage_2d<rg16float, write>;
+@group(0) @binding(2) var inverseLut: texture_storage_2d<rg16float, write>;
+
+fn clampPoint(value: vec2<f32>) -> vec2<f32> {
+  let width = params.size.x;
+  let height = params.size.y;
+  return vec2<f32>(
+    clamp(value.x, 0.0, width),
+    clamp(value.y, 0.0, height)
+  );
+}
+
+fn normalizeCoord(coord: vec2<f32>) -> vec2<f32> {
+  let invSize = params.size.zw;
+  return coord * invSize * 2.0 - vec2<f32>(1.0, 1.0);
+}
+
+fn denormalizeCoord(coord: vec2<f32>) -> vec2<f32> {
+  return (coord * 0.5 + vec2<f32>(0.5, 0.5)) * params.size.xy;
+}
+
+fn mapForward(coord: vec2<f32>) -> vec2<f32> {
+  let aspect = params.factors.x;
+  let norm = normalizeCoord(coord);
+  var p = vec2<f32>(norm.x * aspect, norm.y);
+  let r2 = dot(p, p);
+  let r4 = r2 * r2;
+  let factor = 1.0 + params.factors.y * r2 + params.factors.z * r4;
+  p = p * factor;
+  let distorted = vec2<f32>(p.x / aspect, p.y);
+  return clampPoint(denormalizeCoord(distorted));
+}
+
+fn solveRadius(distorted: f32) -> f32 {
+  if (distorted == 0.0) {
+    return 0.0;
+  }
+  var radius = distorted;
+  for (var i = 0; i < 8; i = i + 1) {
+    let r2 = radius * radius;
+    let r4 = r2 * r2;
+    let value = radius + params.factors.y * radius * r2 + params.factors.z * radius * r4 - distorted;
+    let derivative = 1.0 + 3.0 * params.factors.y * r2 + 5.0 * params.factors.z * r4;
+    if (abs(derivative) < 1e-6) {
+      break;
+    }
+    radius = radius - value / derivative;
+  }
+  return radius;
+}
+
+fn mapInverse(coord: vec2<f32>) -> vec2<f32> {
+  let aspect = params.factors.x;
+  let norm = normalizeCoord(coord);
+  var p = vec2<f32>(norm.x * aspect, norm.y);
+  let radiusPrime = length(p);
+  if (radiusPrime == 0.0) {
+    return vec2<f32>(0.5, 0.5) * params.size.xy;
+  }
+  let radius = solveRadius(radiusPrime);
+  let scale = radius / radiusPrime;
+  p = p * scale;
+  let undistorted = vec2<f32>(p.x / aspect, p.y);
+  return clampPoint(denormalizeCoord(undistorted));
+}
+
+@compute @workgroup_size(8, 8)
+fn cs_main(@builtin(global_invocation_id) id: vec3<u32>) {
+  let width = u32(params.size.x + 0.5);
+  let height = u32(params.size.y + 0.5);
+  if (id.x >= width || id.y >= height) {
+    return;
+  }
+
+  let pixel = vec2<f32>(f32(id.x) + 0.5, f32(id.y) + 0.5);
+  let forward = mapForward(pixel);
+  let inverse = mapInverse(pixel);
+  textureStore(forwardLut, vec2<i32>(i32(id.x), i32(id.y)), vec4<f32>(forward, 0.0, 1.0));
+  textureStore(inverseLut, vec2<i32>(i32(id.x), i32(id.y)), vec4<f32>(inverse, 0.0, 1.0));
+}

--- a/src/lib/crt/types.ts
+++ b/src/lib/crt/types.ts
@@ -22,14 +22,26 @@ export interface CaptureFrame {
   dpr: number;
 }
 
-export const UNIFORM_FLOAT_COUNT = 16;
+export const UNIFORM_FLOAT_COUNT = 28;
 
 export interface CRTGpuRenderer {
   readonly mode: Exclude<CRTRenderMode, 'css'>;
   init(canvas: HTMLCanvasElement): Promise<void>;
   render(uniforms: Float32Array): void;
-  resize(width: number, height: number): void;
+  resize(width: number, height: number, cssWidth: number, cssHeight: number): void;
   updateTexture(frame: CaptureFrame): Promise<void>;
+  updateGeometry(params: {
+    width: number;
+    height: number;
+    dpr: number;
+    k1: number;
+    k2: number;
+  }, lutData?: {
+    forward: Float32Array;
+    inverse: Float32Array;
+    width: number;
+    height: number;
+  }): Promise<void>;
   destroy(): void;
 }
 

--- a/src/lib/crt/webgpuRenderer.ts
+++ b/src/lib/crt/webgpuRenderer.ts
@@ -1,3 +1,4 @@
+import lutShaderSource from './shaders/crtLut.wgsl?raw';
 import shaderSource from './shaders/crt.wgsl?raw';
 import type { CaptureFrame, CRTGpuRenderer } from './types';
 import { UNIFORM_FLOAT_COUNT } from './types';
@@ -7,26 +8,33 @@ interface TextureSize {
   height: number;
 }
 
+const LUT_WORKGROUP_SIZE = 8;
+
 export class WebGpuRenderer implements CRTGpuRenderer {
   readonly mode = 'webgpu' as const;
 
   private device: GPUDevice | null = null;
   private context: GPUCanvasContext | null = null;
   private pipeline: GPURenderPipeline | null = null;
+  private computePipeline: GPUComputePipeline | null = null;
   private sampler: GPUSampler | null = null;
   private uniformBuffer: GPUBuffer | null = null;
+  private geometryUniformBuffer: GPUBuffer | null = null;
   private bindGroup: GPUBindGroup | null = null;
-  private texture: GPUTexture | null = null;
-  private textureSize: TextureSize | null = null;
+  private computeBindGroup: GPUBindGroup | null = null;
+  private sceneTexture: GPUTexture | null = null;
+  private sceneTextureSize: TextureSize | null = null;
+  private forwardLutTexture: GPUTexture | null = null;
+  private inverseLutTexture: GPUTexture | null = null;
+  private lutSize: TextureSize | null = null;
   private canvas: HTMLCanvasElement | null = null;
   private format: GPUTextureFormat | null = null;
+  private geometryUniforms = new Float32Array(8);
 
   async init(canvas: HTMLCanvasElement) {
     if (!navigator.gpu) {
       throw new Error('WebGPU unavailable');
     }
-
-    this.canvas = canvas;
 
     const adapter = await navigator.gpu.requestAdapter();
     if (!adapter) {
@@ -34,6 +42,7 @@ export class WebGpuRenderer implements CRTGpuRenderer {
     }
 
     this.device = await adapter.requestDevice();
+    this.canvas = canvas;
     this.context = canvas.getContext('webgpu');
 
     if (!this.context) {
@@ -48,8 +57,9 @@ export class WebGpuRenderer implements CRTGpuRenderer {
       usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_DST
     });
 
-    const module = this.device.createShaderModule({ code: shaderSource });
-    this.pipeline = this.device.createRenderPipeline({
+    const device = this.device;
+    const module = device.createShaderModule({ code: shaderSource });
+    this.pipeline = device.createRenderPipeline({
       layout: 'auto',
       vertex: { module, entryPoint: 'vs_main' },
       fragment: {
@@ -63,12 +73,23 @@ export class WebGpuRenderer implements CRTGpuRenderer {
       }
     });
 
-    this.uniformBuffer = this.device.createBuffer({
+    const lutModule = device.createShaderModule({ code: lutShaderSource });
+    this.computePipeline = device.createComputePipeline({
+      layout: 'auto',
+      compute: { module: lutModule, entryPoint: 'cs_main' }
+    });
+
+    this.uniformBuffer = device.createBuffer({
       size: UNIFORM_FLOAT_COUNT * Float32Array.BYTES_PER_ELEMENT,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
     });
 
-    this.sampler = this.device.createSampler({
+    this.geometryUniformBuffer = device.createBuffer({
+      size: this.geometryUniforms.byteLength,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+
+    this.sampler = device.createSampler({
       magFilter: 'linear',
       minFilter: 'linear',
       addressModeU: 'clamp-to-edge',
@@ -76,8 +97,8 @@ export class WebGpuRenderer implements CRTGpuRenderer {
     });
   }
 
-  private updateBindGroup() {
-    if (!this.device || !this.pipeline || !this.uniformBuffer || !this.sampler || !this.texture) {
+  private updateRenderBindGroup() {
+    if (!this.device || !this.pipeline || !this.uniformBuffer || !this.sampler || !this.sceneTexture || !this.forwardLutTexture) {
       return;
     }
 
@@ -85,34 +106,43 @@ export class WebGpuRenderer implements CRTGpuRenderer {
     this.bindGroup = this.device.createBindGroup({
       layout,
       entries: [
-        {
-          binding: 0,
-          resource: this.sampler
-        },
-        {
-          binding: 1,
-          resource: this.texture.createView()
-        },
-        {
-          binding: 2,
-          resource: { buffer: this.uniformBuffer }
-        }
+        { binding: 0, resource: this.sampler },
+        { binding: 1, resource: this.sceneTexture.createView() },
+        { binding: 2, resource: { buffer: this.uniformBuffer } },
+        { binding: 3, resource: this.forwardLutTexture.createView() }
+      ]
+    });
+  }
+
+  private updateComputeBindGroup() {
+    if (!this.device || !this.computePipeline || !this.geometryUniformBuffer || !this.forwardLutTexture || !this.inverseLutTexture) {
+      return;
+    }
+
+    const layout = this.computePipeline.getBindGroupLayout(0);
+    this.computeBindGroup = this.device.createBindGroup({
+      layout,
+      entries: [
+        { binding: 0, resource: { buffer: this.geometryUniformBuffer } },
+        { binding: 1, resource: this.forwardLutTexture.createView() },
+        { binding: 2, resource: this.inverseLutTexture.createView() }
       ]
     });
   }
 
   async updateTexture(frame: CaptureFrame) {
     if (!this.device) {
+      frame.bitmap.close();
       return;
     }
 
-    const needsResize = !this.textureSize ||
-      this.textureSize.width !== frame.width ||
-      this.textureSize.height !== frame.height;
+    const needsResize = !this.sceneTextureSize ||
+      this.sceneTextureSize.width !== frame.width ||
+      this.sceneTextureSize.height !== frame.height;
 
     if (needsResize) {
-      this.texture?.destroy();
-      this.texture = this.device.createTexture({
+      this.sceneTexture?.destroy();
+      this.sceneTexture = this.device.createTexture({
         size: { width: frame.width, height: frame.height },
         format: 'rgba8unorm',
         usage:
@@ -120,22 +150,86 @@ export class WebGpuRenderer implements CRTGpuRenderer {
           GPUTextureUsage.COPY_DST |
           GPUTextureUsage.RENDER_ATTACHMENT
       });
-      this.textureSize = { width: frame.width, height: frame.height };
-      this.updateBindGroup();
+      this.sceneTextureSize = { width: frame.width, height: frame.height };
+      this.updateRenderBindGroup();
     }
 
-    if (!this.texture) {
+    if (!this.sceneTexture) {
       frame.bitmap.close();
       return;
     }
 
     this.device.queue.copyExternalImageToTexture(
       { source: frame.bitmap },
-      { texture: this.texture },
+      { texture: this.sceneTexture },
       { width: frame.width, height: frame.height }
     );
 
     frame.bitmap.close();
+  }
+
+  async updateGeometry(
+    params: { width: number; height: number; dpr: number; k1: number; k2: number },
+    _lutData?: unknown
+  ) {
+    if (!this.device) {
+      return;
+    }
+
+    const width = Math.max(1, Math.round(params.width));
+    const height = Math.max(1, Math.round(params.height));
+    const needsLutResize = !this.lutSize || this.lutSize.width !== width || this.lutSize.height !== height;
+
+    if (needsLutResize) {
+      this.forwardLutTexture?.destroy();
+      this.inverseLutTexture?.destroy();
+      const size = { width, height };
+      this.forwardLutTexture = this.device.createTexture({
+        size,
+        format: 'rg16float',
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC
+      });
+      this.inverseLutTexture = this.device.createTexture({
+        size,
+        format: 'rg16float',
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC
+      });
+      this.lutSize = size;
+      this.updateRenderBindGroup();
+      this.updateComputeBindGroup();
+    }
+
+    if (!this.computePipeline || !this.computeBindGroup || !this.geometryUniformBuffer || !this.device) {
+      return;
+    }
+
+    this.geometryUniforms[0] = width;
+    this.geometryUniforms[1] = height;
+    this.geometryUniforms[2] = width > 0 ? 1 / width : 0;
+    this.geometryUniforms[3] = height > 0 ? 1 / height : 0;
+    this.geometryUniforms[4] = height > 0 ? width / height : 1;
+    this.geometryUniforms[5] = params.k1;
+    this.geometryUniforms[6] = params.k2;
+    this.geometryUniforms[7] = params.dpr;
+
+    this.device.queue.writeBuffer(
+      this.geometryUniformBuffer,
+      0,
+      this.geometryUniforms.buffer,
+      this.geometryUniforms.byteOffset,
+      this.geometryUniforms.byteLength
+    );
+
+    const encoder = this.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(this.computePipeline);
+    pass.setBindGroup(0, this.computeBindGroup);
+    const groupX = Math.ceil(width / LUT_WORKGROUP_SIZE);
+    const groupY = Math.ceil(height / LUT_WORKGROUP_SIZE);
+    pass.dispatchWorkgroups(groupX, groupY, 1);
+    pass.end();
+
+    this.device.queue.submit([encoder.finish()]);
   }
 
   render(uniforms: Float32Array) {
@@ -166,26 +260,46 @@ export class WebGpuRenderer implements CRTGpuRenderer {
     this.device.queue.submit([encoder.finish()]);
   }
 
-  resize(width: number, height: number) {
+  resize(width: number, height: number, cssWidth: number, cssHeight: number) {
     if (!this.canvas) {
       return;
     }
-    this.canvas.width = width;
-    this.canvas.height = height;
+    if (this.canvas.width !== width) {
+      this.canvas.width = width;
+    }
+    if (this.canvas.height !== height) {
+      this.canvas.height = height;
+    }
+    if (Number.isFinite(cssWidth) && cssWidth > 0) {
+      this.canvas.style.width = `${cssWidth}px`;
+    }
+    if (Number.isFinite(cssHeight) && cssHeight > 0) {
+      this.canvas.style.height = `${cssHeight}px`;
+    }
   }
 
   destroy() {
-    this.texture?.destroy();
-    this.texture = null;
-    this.textureSize = null;
+    this.sceneTexture?.destroy();
+    this.forwardLutTexture?.destroy();
+    this.inverseLutTexture?.destroy();
+    this.sceneTexture = null;
+    this.forwardLutTexture = null;
+    this.inverseLutTexture = null;
+    this.sceneTextureSize = null;
+    this.lutSize = null;
     this.uniformBuffer?.destroy();
+    this.geometryUniformBuffer?.destroy();
     this.uniformBuffer = null;
+    this.geometryUniformBuffer = null;
     (this.device as (GPUDevice & { destroy?: () => void }) | null)?.destroy?.();
     this.device = null;
     this.context = null;
     this.pipeline = null;
+    this.computePipeline = null;
     this.bindGroup = null;
+    this.computeBindGroup = null;
     this.sampler = null;
+    this.canvas = null;
   }
 }
 
@@ -194,4 +308,3 @@ export const createWebGpuRenderer = async (canvas: HTMLCanvasElement) => {
   await renderer.init(canvas);
   return renderer;
 };
-


### PR DESCRIPTION
## Summary
- add geometry math utilities, half-float conversion, LUT worker/controller, and event proxy plumbing for the CRT pipeline
- update WebGPU/WebGL2 shaders and renderers plus CRTPostFX component to consume LUTs, synthetic cursor uniforms, and adaptive capture controls
- refresh CRT effects store/capture helpers and add NEXT_AGENT notes for follow-up validation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc5579d7f48320ae47779bcdec62e0