### PR TITLE
Fix WebGPU pipelines, LUT formats, and event proxy recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ real time. Pointer events remain routed to the underlying DOM, so links and cont
   flips UVs in the vertex stage while WebGL2 relies on `UNPACK_FLIP_Y_WEBGL`. The Orientation panel in `<CRTPostFX>` previews
   the matrices, DPR, and flip flags alongside a numbered checkerboard to verify top/bottom/left/right alignment after resizes
   or DPR changes.
+- LUT generation now writes to `rgba16float` textures for both forward and inverse maps. WebGPU enables linear sampling only
+  when the adapter advertises float16 filtering, otherwise the fragment shader falls back to a manual four-tap bilinear lookup.
+  The same RGBA16F packing feeds the PicoGL fallback through `OES_texture_half_float` so both pipelines agree on the data
+  layout.
+- Pointer events are proxied through a guarded dispatcher that ignores untrusted events, tracks active pointer IDs to avoid
+  reentrancy, and performs microtask-based hit-tests (temporarily disabling canvas pointer events) before redispatching to the
+  underlying DOM. Synthetic wheel/mouse events inherit the same guard to prevent recursive bubbling loops.
 
 ## Plugin system
 

--- a/src/lib/crt/shaders/crt.vert.glsl
+++ b/src/lib/crt/shaders/crt.vert.glsl
@@ -12,7 +12,6 @@ void main() {
   vec2 position = positions[gl_VertexID];
   gl_Position = vec4(position, 0.0, 1.0);
   vec2 uv = position * 0.5 + vec2(0.5);
-  uv.y = 1.0 - uv.y;
   vUv = uv;
 }
 

--- a/src/lib/crt/shaders/crtLut.wgsl
+++ b/src/lib/crt/shaders/crtLut.wgsl
@@ -1,11 +1,11 @@
 struct LutUniforms {
-  size: vec4<f32>; // x=width, y=height, z=invWidth, w=invHeight
-  factors: vec4<f32>; // x=aspect, y=k1, z=k2, w=unused
+  size: vec4<f32>, // x=width, y=height, z=invWidth, w=invHeight
+  factors: vec4<f32>, // x=aspect, y=k1, z=k2, w=unused
 };
 
 @group(0) @binding(0) var<uniform> params: LutUniforms;
-@group(0) @binding(1) var forwardLut: texture_storage_2d<rg16float, write>;
-@group(0) @binding(2) var inverseLut: texture_storage_2d<rg16float, write>;
+@group(0) @binding(1) var forwardLut: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(2) var inverseLut: texture_storage_2d<rgba16float, write>;
 
 fn clampPoint(value: vec2<f32>) -> vec2<f32> {
   let width = params.size.x;

--- a/src/lib/crt/types.ts
+++ b/src/lib/crt/types.ts
@@ -24,6 +24,10 @@ export interface CaptureFrame {
 
 export const UNIFORM_FLOAT_COUNT = 28;
 
+export interface RendererCapabilities {
+  linearHalfFloatLut: boolean;
+}
+
 export interface CRTGpuRenderer {
   readonly mode: Exclude<CRTRenderMode, 'css'>;
   init(canvas: HTMLCanvasElement): Promise<void>;
@@ -42,6 +46,7 @@ export interface CRTGpuRenderer {
     width: number;
     height: number;
   }): Promise<void>;
+  getCapabilities(): RendererCapabilities;
   destroy(): void;
 }
 


### PR DESCRIPTION
## Summary
- update the WGSL shaders and WebGPU renderer to validate shader modules, label pipelines, and write LUTs to RGBA16F textures with a manual bilinear fallback when float16 filtering is unavailable
- align the WebGL2 LUT packing, add renderer capability reporting, and harden the CRT post-processing component with flip-path diagnostics and a toast when GPU initialization fails
- harden the event proxy by ignoring untrusted events, using microtask hit-testing, and guarding against pointer-id reentrancy

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ccb0068430832086750de92dd23fe3