### PR TITLE
Fix WGSL vertex output struct field separators

### DIFF
--- a/src/lib/crt/shaders/crt.wgsl
+++ b/src/lib/crt/shaders/crt.wgsl
@@ -14,8 +14,8 @@ struct Uniforms {
 @group(0) @binding(3) var forwardLut: texture_2d<f32>;
 
 struct VertexOutput {
-  @builtin(position) position: vec4<f32>;
-  @location(0) uv: vec2<f32>;
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
 };
 
 @vertex


### PR DESCRIPTION
## Summary
- use comma field separators in the CRT vertex output struct so WGSL parses correctly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ccd76d4a088320925a86dad4ab6934